### PR TITLE
Add motion-based cropping and highlight utilities

### DIFF
--- a/02_detect_scenes.py
+++ b/02_detect_scenes.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Pick highlight segments based on audio and motion.
+
+Scores each second by combining RMS audio energy and total motion
+magnitude. Segments whose combined score exceed a dynamic threshold are
+expanded with pre/post roll and merged. Results are written to
+``out/highlights.csv`` with columns ``start,end,score`` in seconds.
+
+CLI options:
+  --video PATH     Input video (default full_game_stabilized.mp4)
+  --min-gap SEC    Minimum gap between merged segments (default 2.0)
+  --pre SEC        Seconds to prepend before a hit (default 5)
+  --post SEC       Seconds to append after a hit (default 6)
+  --max-count N    Limit number of segments (default 40)
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+from pathlib import Path
+
+import cv2
+import librosa
+import numpy as np
+
+
+def compute_audio_scores(path: str) -> np.ndarray:
+    """Return per-second RMS energy."""
+    y, sr = librosa.load(path, sr=None, mono=True)
+    hop = sr  # 1 second steps
+    rms = librosa.feature.rms(y=y, frame_length=sr, hop_length=hop)[0]
+    return rms
+
+
+def compute_motion_scores(path: str) -> np.ndarray:
+    """Return per-second sum of optical-flow magnitudes."""
+    cap = cv2.VideoCapture(path)
+    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    frames_per_sec = int(round(fps))
+    ret, prev = cap.read()
+    if not ret:
+        return np.zeros(0)
+    prev = cv2.cvtColor(prev, cv2.COLOR_BGR2GRAY)
+    acc = []
+    total = 0.0
+    count = 0
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        flow = cv2.calcOpticalFlowFarneback(prev, gray, None, 0.5, 3, 15, 3, 5, 1.2, 0)
+        mag = np.linalg.norm(flow, axis=2).sum()
+        total += mag
+        count += 1
+        if count == frames_per_sec:
+            acc.append(total)
+            total = 0.0
+            count = 0
+        prev = gray
+    if count:
+        acc.append(total)
+    cap.release()
+    return np.array(acc, dtype=float)
+
+
+def normalize(arr: np.ndarray) -> np.ndarray:
+    arr = arr.astype(float)
+    if arr.size == 0:
+        return arr
+    arr -= arr.min()
+    maxv = arr.max()
+    if maxv > 0:
+        arr /= maxv
+    return arr
+
+
+def pick_segments(scores: np.ndarray, rate: float, args) -> list[tuple[float, float, float]]:
+    thr = scores.mean() + scores.std() * 0.5
+    hits = np.where(scores > thr)[0]
+    segments = []
+    for idx in hits:
+        start = max(idx - args.pre, 0)
+        end = idx + 1 + args.post
+        segments.append((start, end, float(scores[idx])))
+    # merge overlapping
+    segments.sort()
+    merged = []
+    for seg in segments:
+        if not merged or seg[0] - merged[-1][1] >= args.min_gap:
+            merged.append(list(seg))
+        else:
+            merged[-1][1] = max(merged[-1][1], seg[1])
+            merged[-1][2] = max(merged[-1][2], seg[2])
+    # limit count
+    merged.sort(key=lambda s: s[2], reverse=True)
+    merged = merged[: args.max_count]
+    merged.sort(key=lambda s: s[0])
+    return [(s[0], s[1], s[2]) for s in merged]
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--video", default="full_game_stabilized.mp4")
+    p.add_argument("--min-gap", type=float, default=2.0)
+    p.add_argument("--pre", type=float, default=5.0)
+    p.add_argument("--post", type=float, default=6.0)
+    p.add_argument("--max-count", type=int, default=40)
+    args = p.parse_args()
+
+    audio = compute_audio_scores(args.video)
+    motion = compute_motion_scores(args.video)
+    n = max(len(audio), len(motion))
+    audio = np.pad(audio, (0, max(0, n - len(audio))))
+    motion = np.pad(motion, (0, max(0, n - len(motion))))
+    audio = normalize(audio)
+    motion = normalize(motion)
+    scores = 0.5 * (audio + motion)
+
+    segs = pick_segments(scores, 1.0, args)
+    out_dir = Path("out")
+    out_dir.mkdir(exist_ok=True)
+    out_csv = out_dir / "highlights.csv"
+    with out_csv.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["start", "end", "score"])
+        for s, e, sc in segs:
+            writer.writerow([f"{s:.2f}", f"{e:.2f}", f"{sc:.3f}"])
+
+
+if __name__ == "__main__":
+    main()

--- a/03_motion_zoom.py
+++ b/03_motion_zoom.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Motion guided auto-crop/zoom.
+
+Reads a video, estimates per-frame motion using background subtraction
+and outputs smoothed crop windows with constant aspect ratio. Crop
+coordinates are written to ``out/crops.jsonl`` and a temporary video is
+produced at ``out/zoomed_temp.mp4`` using a named pipe feeding FFmpeg.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess as sp
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+
+def ensure_bounds(cx, cy, cw, ch, W, H):
+    cx = np.clip(cx, cw / 2, W - cw / 2)
+    cy = np.clip(cy, ch / 2, H - ch / 2)
+    return cx, cy
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--in", dest="inp", default="full_game_stabilized.mp4")
+    p.add_argument("--out", dest="out_dir", default="out")
+    p.add_argument("--width", type=int, default=1920)
+    p.add_argument("--height", type=int, default=1080)
+    p.add_argument("--smooth", type=float, default=0.85)
+    args = p.parse_args()
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(exist_ok=True)
+    jsonl = (out_dir / "crops.jsonl").open("w")
+
+    cap = cv2.VideoCapture(args.inp)
+    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    W = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    H = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    cw, ch = min(args.width, W), min(args.height, H)
+    back = cv2.createBackgroundSubtractorMOG2(history=500, varThreshold=64, detectShadows=False)
+
+    pipe = out_dir / "pipe.raw"
+    if pipe.exists():
+        pipe.unlink()
+    os.mkfifo(pipe)
+    ffmpeg = [
+        "ffmpeg",
+        "-y",
+        "-f",
+        "rawvideo",
+        "-pix_fmt",
+        "bgr24",
+        "-s",
+        f"{cw}x{ch}",
+        "-r",
+        f"{fps}",
+        "-i",
+        str(pipe),
+        "-an",
+        str(out_dir / "zoomed_temp.mp4"),
+    ]
+    proc = sp.Popen(ffmpeg)
+    pipe_f = open(pipe, "wb")
+
+    cx, cy = W / 2, H / 2
+    frame_idx = 0
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        fg = back.apply(frame)
+        _, fg = cv2.threshold(fg, 200, 255, cv2.THRESH_BINARY)
+        fg = cv2.morphologyEx(fg, cv2.MORPH_OPEN, None)
+        cnts, _ = cv2.findContours(fg, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+        if cnts:
+            x, y, w, h = cv2.boundingRect(np.vstack(cnts))
+            tcx, tcy = x + w / 2, y + h / 2
+        else:
+            tcx, tcy = cx, cy
+        # EMA smoothing
+        cx = args.smooth * cx + (1 - args.smooth) * tcx
+        cy = args.smooth * cy + (1 - args.smooth) * tcy
+        # keep inside frame with gentle easing
+        ncx, ncy = ensure_bounds(cx, cy, cw, ch, W, H)
+        cx += (ncx - cx) / 12.0
+        cy += (ncy - cy) / 12.0
+        x0 = int(round(cx - cw / 2))
+        y0 = int(round(cy - ch / 2))
+        jsonl.write(
+            json.dumps({
+                "frame": frame_idx,
+                "t": frame_idx / fps,
+                "x": x0,
+                "y": y0,
+                "w": cw,
+                "h": ch,
+            })
+            + "\n"
+        )
+        crop = frame[y0 : y0 + ch, x0 : x0 + cw]
+        pipe_f.write(crop.tobytes())
+        frame_idx += 1
+
+    pipe_f.close()
+    proc.wait()
+    os.unlink(pipe)
+    jsonl.close()
+    cap.release()
+
+
+if __name__ == "__main__":
+    main()

--- a/04_make_highlights.py
+++ b/04_make_highlights.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Export highlight clips using FFmpeg.
+
+Reads ``out/highlights.csv`` and writes individual clips to
+``out/clips/clip_####.mp4``. Existing clips are skipped unless
+``--overwrite`` is given."""
+from __future__ import annotations
+
+import argparse
+import csv
+import subprocess as sp
+from pathlib import Path
+
+
+def safe_name(idx: int) -> str:
+    return f"clip_{idx:04d}.mp4"
+
+
+def run_ffmpeg(src: str, start: float, end: float, out: Path) -> None:
+    cmd = [
+        "ffmpeg",
+        "-y",
+        "-i",
+        src,
+        "-ss",
+        f"{start}",
+        "-to",
+        f"{end}",
+        "-c",
+        "copy",
+        str(out),
+    ]
+    sp.run(cmd, check=True)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--video", default="full_game_stabilized.mp4")
+    p.add_argument("--csv", default="out/highlights.csv")
+    p.add_argument("--outdir", default="out/clips")
+    p.add_argument("--overwrite", action="store_true")
+    args = p.parse_args()
+
+    outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    with open(args.csv) as f:
+        reader = csv.DictReader(f)
+        for idx, row in enumerate(reader, 1):
+            start = float(row["start"])
+            end = float(row["end"])
+            out = outdir / safe_name(idx)
+            if out.exists() and not args.overwrite:
+                continue
+            run_ffmpeg(args.video, start, end, out)
+
+
+if __name__ == "__main__":
+    main()

--- a/05_make_social_reel.sh
+++ b/05_make_social_reel.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Build a vertical or square reel from top highlight clips.
+TARGET_AR=${TARGET_AR:-9:16}
+MAX_LEN=${MAX_LEN:-90}
+BITRATE=${BITRATE:-6M}
+CSV=out/highlights.csv
+CLIPDIR=out/clips
+OUT=out/social_reel.mp4
+MUSIC=${MUSIC:-}
+N=${1:-10}
+
+set -e
+
+[ -f "$CSV" ] || { echo "Missing $CSV"; exit 1; }
+mkdir -p out
+list=$(mktemp)
+trap 'rm -f "$list"' EXIT
+
+tail -n +2 "$CSV" | sort -t, -k3 -nr | head -n $N |
+  nl -w4 -n rz | while IFS=$'\t,' read -r idx start end score; do
+    printf "file '%s/clip_%04d.mp4'\n" "$CLIPDIR" "$idx" >> "$list"
+  done
+
+if [ "$TARGET_AR" = "9:16" ]; then
+  VF="scale=-2:1920,crop=1080:1920,setsar=1,drawtext=font=Sans:text='Highlights':x=(w-text_w)/2:y=40:fontsize=64:fontcolor=white:enable='lt(t,2)'"
+else
+  VF="scale=1080:-2,pad=1080:1080:(1080-iw)/2:(1080-ih)/2,setsar=1,drawtext=font=Sans:text='Highlights':x=(w-text_w)/2:y=40:fontsize=64:fontcolor=white:enable='lt(t,2)'"
+fi
+
+if [ -n "$MUSIC" ]; then
+  ffmpeg -y -f concat -safe 0 -i "$list" -i "$MUSIC" \
+    -filter_complex "[0:v]$VF[v];[0:a][1:a]amix=inputs=2:duration=shortest[a]" \
+    -map '[v]' -map '[a]' -c:v libx264 -b:v $BITRATE -c:a aac -t $MAX_LEN "$OUT"
+else
+  ffmpeg -y -f concat -safe 0 -i "$list" \
+    -vf "$VF" -c:v libx264 -b:v $BITRATE -c:a aac -t $MAX_LEN "$OUT"
+fi


### PR DESCRIPTION
## Summary
- Detect key moments by scoring audio energy and motion to write `out/highlights.csv`
- Track motion to generate smoothed crop windows and preview video via FFmpeg pipe
- Export highlight clips and assemble a vertical or square social reel

## Testing
- `python -m py_compile 02_detect_scenes.py 03_motion_zoom.py 04_make_highlights.py`
- `bash -n 05_make_social_reel.sh`
- ⚠️ `python 02_detect_scenes.py --help` (missing cv2; attempted `pip install opencv-python-headless librosa` but failed: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68c6d543d85c832da2775447ca2c5658