### PR TITLE
Add minimum duration check for highlight clips

### DIFF
--- a/04_make_highlights.py
+++ b/04_make_highlights.py
@@ -39,6 +39,7 @@ def main() -> None:
     p.add_argument("--csv", default="out/highlights.csv")
     p.add_argument("--outdir", default="out/clips")
     p.add_argument("--overwrite", action="store_true")
+    p.add_argument("--min-dur", type=float, default=3.0, help="skip clips shorter than this")
     args = p.parse_args()
 
     outdir = Path(args.outdir)
@@ -46,13 +47,18 @@ def main() -> None:
 
     with open(args.csv) as f:
         reader = csv.DictReader(f)
-        for idx, row in enumerate(reader, 1):
+        idx = 1
+        for row in reader:
             start = float(row["start"])
             end = float(row["end"])
+            if end - start < args.min_dur:
+                continue
             out = outdir / safe_name(idx)
             if out.exists() and not args.overwrite:
+                idx += 1
                 continue
             run_ffmpeg(args.video, start, end, out)
+            idx += 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- skip highlight segments shorter than 3 seconds when rendering clips
- allow configuring minimum clip duration via `--min-dur`

## Testing
- `python -m py_compile 04_make_highlights.py`


------
https://chatgpt.com/codex/tasks/task_e_68c80acbe1e0832d823374000db1f7c5