### PR TITLE
Add unified soccer highlights package and CLI

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,55 @@
+paths:
+  video: full_game_stabilized.mp4
+  output_dir: out
+
+detect:
+  min_gap: 2.0
+  pre: 5.0
+  post: 6.0
+  max_count: 40
+  audio_weight: 0.5
+  threshold_std: 0.5
+  hysteresis: 0.3
+  sustain: 1.0
+
+shrink:
+  mode: smart
+  pre: 3.0
+  post: 5.0
+  aspect: horizontal
+  zoom: 1.2
+  bias_blue: false
+
+clips:
+  min_duration: 3.0
+  preset: veryfast
+  crf: 20
+  audio_bitrate: 160k
+  workers: 2
+  overwrite: false
+
+rank:
+  k: 10
+  max_len: 18.0
+  sustain: 1.25
+  min_tail: 6.0
+
+reels:
+  profile: broadcast
+  topk_title: Top Plays
+  full_title: Full Highlights
+
+colors:
+  calibrate: false
+  pitch_hsv:
+    h: 90
+    s: 80
+    v: 80
+  team_primary:
+    h: 210
+    s: 70
+    v: 70
+  team_secondary:
+    h: 30
+    s: 70
+    v: 70

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,20 @@
+# Examples
+
+The `generate_sample.py` script creates a short synthetic match clip that is small
+enough for regression tests. Run it from PowerShell with:
+
+```powershell
+python .\examples\generate_sample.py
+```
+
+After generating the clip you can process it end-to-end using:
+
+```powershell
+soccerhl detect --config .\examples\sample_config.yaml
+soccerhl shrink --config .\examples\sample_config.yaml --csv .\examples\out\highlights.csv --out .\examples\out\highlights_smart.csv
+soccerhl clips --config .\examples\sample_config.yaml --csv .\examples\out\highlights_smart.csv --outdir .\examples\out\clips
+soccerhl topk --config .\examples\sample_config.yaml --candirs .\examples\out\clips
+soccerhl reel --config .\examples\sample_config.yaml --list .\examples\out\smart_top10_concat.txt --out .\examples\out\reels\sample_top10.mp4
+```
+
+All commands work on Windows PowerShell without line continuations.

--- a/examples/generate_sample.py
+++ b/examples/generate_sample.py
@@ -1,0 +1,34 @@
+"""Generate a tiny synthetic soccer-like clip for testing using FFmpeg."""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def main(output: Path = Path("sample_game.mp4"), duration: int = 12, fps: int = 24) -> None:
+    size = "640x360"
+    filters = ",".join([
+        "drawbox=x=10:y=h/3:w=30:h=h/3:color=white@1:t=2",
+        "drawbox=x=w-40:y=h/3:w=30:h=h/3:color=white@1:t=2",
+        "drawbox=x=80+80*sin(PI*(t-3)):y=h/2+60*cos(PI*(t-3)):w=24:h=24:color=white@1:enable='between(t,3,5)'",
+        "drawbox=x=w-(80+80*sin(PI*(t-8))):y=h/2+60*sin(1.5*PI*(t-8)):w=24:h=24:color=white@1:enable='between(t,8,10)'",
+        "drawbox=x=w/2+120*sin(t*0.6):y=h/2+60*cos(t*0.6):w=30:h=50:color=0x3c3cee@1",
+    ])
+    cmd = [
+        "ffmpeg",
+        "-hide_banner",
+        "-y",
+        "-f",
+        "lavfi",
+        "-i",
+        f"color=c=0x1e6e1e:s={size}:d={duration}:r={fps}",
+        "-vf",
+        filters,
+        str(output),
+    ]
+    subprocess.run(cmd, check=True)
+    print(f"Wrote {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sample_config.yaml
+++ b/examples/sample_config.yaml
@@ -1,0 +1,34 @@
+paths:
+  video: examples/sample_game.mp4
+  output_dir: examples/out
+
+detect:
+  min_gap: 1.0
+  pre: 2.0
+  post: 3.0
+  max_count: 12
+  audio_weight: 0.0
+  threshold_std: 0.3
+  hysteresis: 0.25
+  sustain: 0.5
+
+shrink:
+  mode: smart
+  pre: 2.0
+  post: 3.0
+  aspect: horizontal
+  zoom: 1.0
+  bias_blue: true
+
+clips:
+  min_duration: 2.0
+  workers: 1
+
+rank:
+  k: 3
+  max_len: 12.0
+  min_tail: 4.0
+
+reels:
+  profile: broadcast
+  topk_title: Sample Top Plays

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "soccer-highlights"
+version = "0.1.0"
+description = "End-to-end soccer highlight generation toolkit"
+authors = [{ name = "OpenAI", email = "opensource@example.com" }]
+requires-python = ">=3.9"
+dependencies = [
+    "loguru",
+    "pydantic>=1.10",
+    "PyYAML",
+    "tqdm",
+    "numpy",
+    "opencv-python",
+    "librosa",
+]
+
+[project.optional-dependencies]
+dev = ["pytest"]
+
+[project.scripts]
+soccerhl = "soccer_highlights.cli:main"
+
+[tool.pytest.ini_options]
+addopts = "-m 'not slow'"
+markers = ["slow: marks tests that take longer to run"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,23 @@
+[metadata]
+name = soccer-highlights
+version = 0.1.0
+
+[options]
+packages = find:
+install_requires =
+    loguru
+    pydantic>=1.10
+    PyYAML
+    tqdm
+    numpy
+    opencv-python
+    librosa
+python_requires = >=3.9
+
+[options.extras_require]
+dev =
+    pytest
+
+[options.entry_points]
+console_scripts =
+    soccerhl = soccer_highlights.cli:main

--- a/soccer_highlights/__init__.py
+++ b/soccer_highlights/__init__.py
@@ -1,0 +1,5 @@
+"""Soccer highlights extraction toolkit."""
+
+from .config import AppConfig, load_config
+
+__all__ = ["AppConfig", "load_config"]

--- a/soccer_highlights/__main__.py
+++ b/soccer_highlights/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/soccer_highlights/_loguru.py
+++ b/soccer_highlights/_loguru.py
@@ -1,0 +1,30 @@
+"""Fallback logger mirroring the loguru API when loguru is unavailable."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+try:  # pragma: no cover
+    from loguru import logger  # type: ignore
+except Exception:  # pragma: no cover
+    _logger = logging.getLogger("soccer_highlights")
+    if not _logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter("[%(levelname)s] %(message)s")
+        handler.setFormatter(formatter)
+        _logger.addHandler(handler)
+    _logger.setLevel(logging.INFO)
+
+    class _ProxyLogger:
+        def add(self, sink: Any, level: str = "INFO") -> None:
+            if isinstance(sink, int):
+                return
+            _logger.setLevel(level)
+
+        def remove(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        def __getattr__(self, name: str) -> Callable[..., None]:
+            return getattr(_logger, name)
+
+    logger = _ProxyLogger()

--- a/soccer_highlights/_pydantic_compat.py
+++ b/soccer_highlights/_pydantic_compat.py
@@ -1,0 +1,108 @@
+"""Lightweight compatibility layer for pydantic."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Type
+
+try:  # pragma: no cover - use real pydantic when available
+    from pydantic import BaseModel, Field, validator  # type: ignore
+except Exception:  # pragma: no cover
+    class FieldInfo:
+        def __init__(self, default: Any = ..., default_factory: Any | None = None, **kwargs: Any) -> None:
+            self.default = default
+            self.default_factory = default_factory
+            self.extra = kwargs
+            self.ge = kwargs.get('ge')
+            self.le = kwargs.get('le')
+
+    def Field(default: Any = ..., default_factory: Any | None = None, **kwargs: Any) -> FieldInfo:
+        return FieldInfo(default=default, default_factory=default_factory, **kwargs)
+
+    def validator(field_name: str):
+        def decorator(func):
+            func._validator_field = field_name
+            return func
+        return decorator
+
+    class BaseModelMeta(type):
+        def __new__(mcls, name: str, bases: tuple[type, ...], namespace: Dict[str, Any]):
+            annotations: Dict[str, Any] = {}
+            for base in reversed(bases):
+                annotations.update(getattr(base, "__annotations__", {}))
+            annotations.update(namespace.get("__annotations__", {}))
+            field_defs: Dict[str, FieldInfo] = {}
+            field_types: Dict[str, Any] = {}
+            validators: Dict[str, Any] = {}
+            for key, value in list(namespace.items()):
+                if callable(value) and hasattr(value, "_validator_field"):
+                    validators[value._validator_field] = value
+            for key, anno in annotations.items():
+                field_types[key] = anno
+                default = namespace.get(key, ...)
+                if isinstance(default, FieldInfo):
+                    field_defs[key] = default
+                    namespace.pop(key, None)
+                elif default is ...:
+                    field_defs[key] = FieldInfo(default=...)
+                else:
+                    field_defs[key] = FieldInfo(default=default)
+            namespace["__field_definitions__"] = field_defs
+            namespace["__field_types__"] = field_types
+            namespace["__validators__"] = validators
+            return super().__new__(mcls, name, bases, namespace)
+
+    class BaseModel(metaclass=BaseModelMeta):
+        __field_definitions__: Dict[str, FieldInfo]
+        __field_types__: Dict[str, Any]
+        __validators__: Dict[str, Any]
+
+        def __init__(self, **data: Any) -> None:
+            for name, info in self.__field_definitions__.items():
+                value = data.get(name, ...)
+                if value is ...:
+                    if info.default is not ...:
+                        value = info.default
+                    elif info.default_factory is not None:
+                        value = info.default_factory()
+                    else:
+                        value = None
+                value = self._coerce(name, value)
+                info = self.__field_definitions__[name]
+                if info.ge is not None and value is not None and value < info.ge:
+                    raise ValueError(f'{name} must be >= {info.ge}')
+                if info.le is not None and value is not None and value > info.le:
+                    raise ValueError(f'{name} must be <= {info.le}')
+                validator_fn = self.__validators__.get(name)
+                if validator_fn is not None:
+                    value = validator_fn(self.__class__, value)
+                setattr(self, name, value)
+
+        def _coerce(self, name: str, value: Any) -> Any:
+            anno = self.__field_types__.get(name)
+            origin = getattr(anno, "__origin__", None)
+            if origin is list and isinstance(value, list):
+                subtype = anno.__args__[0]
+                return [self._coerce_value(subtype, item) for item in value]
+            if origin is dict and isinstance(value, dict):
+                key_type, val_type = anno.__args__
+                return {
+                    self._coerce_value(key_type, k): self._coerce_value(val_type, v)
+                    for k, v in value.items()
+                }
+            return self._coerce_value(anno, value)
+
+        def _coerce_value(self, anno: Any, value: Any) -> Any:
+            if anno is None:
+                return value
+            if isinstance(anno, type) and issubclass(anno, BaseModel) and isinstance(value, dict):
+                return anno.parse_obj(value)
+            if anno is Path and isinstance(value, str):
+                return Path(value)
+            return value
+
+        @classmethod
+        def parse_obj(cls: Type["BaseModel"], obj: Dict[str, Any]) -> "BaseModel":
+            return cls(**obj)
+
+        def dict(self) -> Dict[str, Any]:
+            return self.__dict__.copy()

--- a/soccer_highlights/_tqdm.py
+++ b/soccer_highlights/_tqdm.py
@@ -1,0 +1,27 @@
+
+"""Fallback wrapper for tqdm progress bars."""
+from __future__ import annotations
+
+try:  # pragma: no cover
+    from tqdm import tqdm  # type: ignore
+except Exception:  # pragma: no cover
+    class _Dummy:
+        def __init__(self, iterable=None):
+            self.iterable = iterable or []
+
+        def __iter__(self):
+            return iter(self.iterable)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def update(self, *args, **kwargs):
+            return None
+
+    def tqdm(iterable=None, **kwargs):  # type: ignore
+        if iterable is None:
+            return _Dummy()
+        return iterable

--- a/soccer_highlights/cli.py
+++ b/soccer_highlights/cli.py
@@ -1,0 +1,230 @@
+"""Console entry point for the soccer highlights suite."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import List
+
+from ._loguru import logger
+
+from .clips import run_clips
+from .config import AppConfig, load_config
+from .detect import run_detect
+from .rank import run_topk
+from .reels import render_reel
+from .shrink import run_shrink
+from .utils import load_report, summary_stats
+
+
+def _configure_logging(verbose: bool) -> None:
+    logger.remove()
+    level = "DEBUG" if verbose else "INFO"
+    logger.add(sys.stderr, level=level)
+
+
+def _load_config(path: Path) -> AppConfig:
+    if not path.exists():
+        logger.info("Using default configuration; no %s found", path)
+    return load_config(path)
+
+
+def _resolve_video_path(config: AppConfig, override: str | None) -> Path:
+    return Path(override) if override else Path(config.paths.video)
+
+
+def cmd_detect(config: AppConfig, args: argparse.Namespace) -> None:
+    if args.pre is not None:
+        config.detect.pre = args.pre
+    if args.post is not None:
+        config.detect.post = args.post
+    if args.max_count is not None:
+        config.detect.max_count = args.max_count
+    if args.min_gap is not None:
+        config.detect.min_gap = args.min_gap
+    if args.audio_weight is not None:
+        config.detect.audio_weight = args.audio_weight
+    video_path = _resolve_video_path(config, args.video)
+    config.paths.video = video_path
+    out_csv = Path(args.out or (config.output_dir / "highlights.csv"))
+    out_csv.parent.mkdir(parents=True, exist_ok=True)
+    result = run_detect(config, video_path, out_csv)
+    stats = summary_stats(result.windows)
+    report = load_report(config.output_dir)
+    report.update(
+        "detect",
+        {
+            **stats,
+            "adaptive_threshold": round(result.adaptive_threshold, 3),
+            "low_threshold": round(result.low_threshold, 3),
+            "mean_score": round(result.mean_score, 3),
+            "std_score": round(result.std_score, 3),
+            "output": out_csv.as_posix(),
+        },
+    )
+
+
+def cmd_shrink(config: AppConfig, args: argparse.Namespace) -> None:
+    if args.mode:
+        config.shrink.mode = args.mode
+    if args.pre is not None:
+        config.shrink.pre = args.pre
+    if args.post is not None:
+        config.shrink.post = args.post
+    if args.aspect:
+        config.shrink.aspect = args.aspect
+    if args.zoom is not None:
+        config.shrink.zoom = args.zoom
+    if args.bias_blue:
+        config.shrink.bias_blue = True
+    if args.write_clips:
+        config.shrink.write_clips = Path(args.write_clips)
+    video_path = _resolve_video_path(config, args.video)
+    config.paths.video = video_path
+    csv_in = Path(args.csv or (config.output_dir / "highlights.csv"))
+    csv_out = Path(args.out or (config.output_dir / "highlights_tight.csv"))
+    refined = run_shrink(config, video_path, csv_in, csv_out)
+    stats = summary_stats(refined)
+    report = load_report(config.output_dir)
+    report.update(
+        "shrink",
+        {**stats, "mode": config.shrink.mode, "output": csv_out.as_posix()},
+    )
+
+
+def cmd_clips(config: AppConfig, args: argparse.Namespace) -> None:
+    if args.min_dur is not None:
+        config.clips.min_duration = args.min_dur
+    if args.workers is not None:
+        config.clips.workers = args.workers
+    if args.overwrite:
+        config.clips.overwrite = True
+    video_path = _resolve_video_path(config, args.video)
+    config.paths.video = video_path
+    csv_path = Path(args.csv or (config.output_dir / "highlights_tight.csv"))
+    out_dir = Path(args.outdir or (config.output_dir / "clips"))
+    exported = run_clips(config, video_path, csv_path, out_dir)
+    report = load_report(config.output_dir)
+    report.update(
+        "clips",
+        {
+            "count": len(exported),
+            "output_dir": out_dir.as_posix(),
+        },
+    )
+
+
+def cmd_topk(config: AppConfig, args: argparse.Namespace) -> None:
+    csv_out = Path(args.csv or (config.output_dir / "smart_top10.csv"))
+    concat_out = Path(args.list or (config.output_dir / "smart_top10_concat.txt"))
+    if args.k is not None:
+        config.rank.k = args.k
+    if args.max_len is not None:
+        config.rank.max_len = args.max_len
+    dirs: List[Path] = []
+    if args.candirs:
+        dirs = [Path(p.strip()) for p in args.candirs.split(",") if p.strip()]
+    else:
+        dirs = [config.output_dir / "clips", config.output_dir / "clips_acc"]
+    ranked = run_topk(config, dirs, csv_out, concat_out)
+    report = load_report(config.output_dir)
+    top_score = max((clip.score for clip in ranked), default=0.0)
+    report.update(
+        "topk",
+        {
+            "count": len(ranked),
+            "top_score": round(top_score, 3),
+            "csv": csv_out.as_posix(),
+            "concat": concat_out.as_posix(),
+        },
+    )
+
+
+def cmd_reel(config: AppConfig, args: argparse.Namespace) -> None:
+    list_path = Path(args.list or (config.output_dir / "smart_top10_concat.txt"))
+    out_path = Path(args.out or (config.output_dir / "reels" / "top10.mp4"))
+    title = args.title or config.reels.topk_title
+    profile = args.profile or config.reels.profile
+    duration = render_reel(config, list_path, out_path, title, profile)
+    report = load_report(config.output_dir)
+    report.update(
+        "reel",
+        {
+            "profile": profile,
+            "output": out_path.as_posix(),
+            "duration": round(duration, 2),
+        },
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="soccerhl", description="Soccer highlights end-to-end pipeline")
+    parser.add_argument("--config", default="config.yaml", help="Path to YAML configuration file")
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    detect_p = sub.add_parser("detect", help="Run motion/audio detection")
+    detect_p.add_argument("--video")
+    detect_p.add_argument("--out")
+    detect_p.add_argument("--pre", type=float)
+    detect_p.add_argument("--post", type=float)
+    detect_p.add_argument("--min-gap", dest="min_gap", type=float)
+    detect_p.add_argument("--max-count", type=int)
+    detect_p.add_argument("--audio-weight", type=float)
+    detect_p.set_defaults(func=cmd_detect)
+
+    shrink_p = sub.add_parser("shrink", help="Refine highlight windows")
+    shrink_p.add_argument("--video")
+    shrink_p.add_argument("--csv")
+    shrink_p.add_argument("--out")
+    shrink_p.add_argument("--mode", choices=["simple", "smart"])
+    shrink_p.add_argument("--pre", type=float)
+    shrink_p.add_argument("--post", type=float)
+    shrink_p.add_argument("--aspect", choices=["horizontal", "vertical"])
+    shrink_p.add_argument("--zoom", type=float)
+    shrink_p.add_argument("--bias-blue", action="store_true")
+    shrink_p.add_argument("--write-clips")
+    shrink_p.set_defaults(func=cmd_shrink)
+
+    clips_p = sub.add_parser("clips", help="Export clips with ffmpeg")
+    clips_p.add_argument("--video")
+    clips_p.add_argument("--csv")
+    clips_p.add_argument("--outdir")
+    clips_p.add_argument("--min-dur", type=float)
+    clips_p.add_argument("--workers", type=int)
+    clips_p.add_argument("--overwrite", action="store_true")
+    clips_p.set_defaults(func=cmd_clips)
+
+    topk_p = sub.add_parser("topk", help="Score and pick top clips")
+    topk_p.add_argument("--candirs", help="Comma separated directories of candidate clips")
+    topk_p.add_argument("--csv")
+    topk_p.add_argument("--list")
+    topk_p.add_argument("--k", type=int)
+    topk_p.add_argument("--max-len", type=float)
+    topk_p.set_defaults(func=cmd_topk)
+
+    reel_p = sub.add_parser("reel", help="Render final reel video")
+    reel_p.add_argument("--list")
+    reel_p.add_argument("--out")
+    reel_p.add_argument("--title")
+    reel_p.add_argument("--profile")
+    reel_p.set_defaults(func=cmd_reel)
+
+    return parser
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    _configure_logging(args.verbose)
+    config_path = Path(args.config)
+    config = _load_config(config_path)
+    config.paths.output_dir.mkdir(parents=True, exist_ok=True)
+    if not hasattr(args, "func"):
+        parser.print_help()
+        return
+    args.func(config, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/soccer_highlights/clips.py
+++ b/soccer_highlights/clips.py
@@ -1,0 +1,103 @@
+"""Clip exporter using ffmpeg with frame-accurate trimming."""
+from __future__ import annotations
+
+import concurrent.futures
+from pathlib import Path
+from typing import List
+
+from ._loguru import logger
+from ._tqdm import tqdm
+
+from .config import AppConfig
+from .io import VideoStreamInfo, run_command, seconds_to_timestamp, video_stream_info
+from .utils import HighlightWindow, read_highlights
+
+
+def _seek_mode(start: float, fps: float) -> str:
+    frac = abs(start * fps - round(start * fps))
+    if start < 3.0 or frac > 0.01:
+        return "output"
+    return "input"
+
+
+def _build_command(video_path: Path, out_path: Path, start: float, end: float, info: VideoStreamInfo, config: AppConfig) -> List[str]:
+    duration = max(0.05, end - start)
+    fade = min(0.1, duration / 2)
+    afilter = (
+        f"afade=t=in:st=0:d={fade:.3f},"
+        f"afade=t=out:st={max(duration - fade, 0):.3f}:d={fade:.3f},"
+        "asetpts=N/SR/TB,aresample=async=1"
+    )
+    seek_mode = _seek_mode(start, info.fps)
+    cmd: List[str] = ["ffmpeg", "-hide_banner", "-y"]
+    if seek_mode == "input":
+        cmd += ["-ss", seconds_to_timestamp(start)]
+    cmd += ["-i", str(video_path)]
+    if seek_mode == "output":
+        cmd += ["-ss", seconds_to_timestamp(start)]
+    cmd += [
+        "-t",
+        seconds_to_timestamp(duration),
+        "-avoid_negative_ts",
+        "make_zero",
+        "-c:v",
+        "libx264",
+        "-preset",
+        config.clips.preset,
+        "-crf",
+        str(config.clips.crf),
+        "-c:a",
+        "aac",
+        "-b:a",
+        config.clips.audio_bitrate,
+        "-af",
+        afilter,
+        "-shortest",
+        "-movflags",
+        "+faststart",
+        str(out_path),
+    ]
+    return cmd
+
+
+def _export_one(video_path: Path, info: VideoStreamInfo, task: HighlightWindow, out_path: Path, config: AppConfig, overwrite: bool) -> bool:
+    if out_path.exists() and not overwrite:
+        logger.debug("Skipping existing %s", out_path)
+        return False
+    cmd = _build_command(video_path, out_path, task.start, task.end, info, config)
+    run_command(cmd)
+    return True
+
+
+def export_clips(config: AppConfig, video_path: Path, csv_path: Path, out_dir: Path) -> List[Path]:
+    info = video_stream_info(video_path)
+    windows = [w for w in read_highlights(csv_path) if w.end - w.start >= config.clips.min_duration]
+    if not windows:
+        logger.warning("No clips to export from %s", csv_path)
+        return []
+    out_dir.mkdir(parents=True, exist_ok=True)
+    tasks = []
+    for idx, win in enumerate(windows, start=1):
+        out_path = out_dir / f"clip_{idx:04d}.mp4"
+        tasks.append((idx, win, out_path))
+
+    exported: List[Path] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=config.clips.workers) as executor:
+        future_map = {
+            executor.submit(_export_one, video_path, info, win, out_path, config, config.clips.overwrite): (idx, out_path)
+            for idx, win, out_path in tasks
+        }
+        for future in tqdm(concurrent.futures.as_completed(future_map), total=len(future_map), desc="clips", unit="clip", leave=False):
+            idx, out_path = future_map[future]
+            try:
+                result = future.result()
+            except Exception as exc:
+                logger.error("Clip %d failed: %s", idx, exc)
+            else:
+                if result:
+                    exported.append(out_path)
+    return exported
+
+
+def run_clips(config: AppConfig, video_path: Path, csv_path: Path, out_dir: Path) -> List[Path]:
+    return export_clips(config, video_path, csv_path, out_dir)

--- a/soccer_highlights/colors.py
+++ b/soccer_highlights/colors.py
@@ -1,0 +1,123 @@
+"""Color utilities for pitch/kit masking and auto calibration."""
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Iterable, Tuple
+
+import cv2
+import numpy as np
+from ._loguru import logger
+
+from .config import ColorsConfig, HSVRange
+
+
+@dataclass
+class HSVTolerance:
+    h: float = 12.0
+    s: float = 60.0
+    v: float = 60.0
+
+
+DEFAULT_TOLERANCE = HSVTolerance()
+
+
+def hsv_mask(frame_bgr: np.ndarray, center: HSVRange, tol: HSVTolerance = DEFAULT_TOLERANCE) -> np.ndarray:
+    hsv = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2HSV).astype(np.float32)
+    lower = np.array([
+        max(0.0, center.h - tol.h),
+        max(0.0, center.s - tol.s),
+        max(0.0, center.v - tol.v),
+    ])
+    upper = np.array([
+        min(180.0, center.h + tol.h),
+        min(255.0, center.s + tol.s),
+        min(255.0, center.v + tol.v),
+    ])
+    mask = cv2.inRange(hsv, lower, upper)
+    return mask
+
+
+def calibrate_colors(video_path: str, config: ColorsConfig, sample_frames: int = 20) -> ColorsConfig:
+    logger.info("Calibrating HSV ranges from %s", video_path)
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        logger.warning("Failed to open %s for calibration", video_path)
+        return config
+
+    total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    if total_frames <= 0:
+        cap.release()
+        logger.warning('Video has no frames; skipping calibration')
+        return config
+    indices = sorted(random.sample(range(total_frames), min(sample_frames, total_frames)))
+
+    samples_pitch = []
+    samples_team = []
+
+    for idx in indices:
+        cap.set(cv2.CAP_PROP_POS_FRAMES, idx)
+        ok, frame = cap.read()
+        if not ok:
+            continue
+        hsv = cv2.cvtColor(frame, cv2.COLOR_BGR2HSV)
+        h, w = hsv.shape[:2]
+        center_region = hsv[h // 3 : 2 * h // 3, w // 4 : 3 * w // 4]
+        flat = center_region.reshape(-1, 3).astype(np.float32)
+        if flat.size == 0:
+            continue
+        k = min(3, len(flat))
+        criteria = (cv2.TERM_CRITERIA_EPS + cv2.TERM_CRITERIA_MAX_ITER, 20, 1.0)
+        compactness, labels, centers = cv2.kmeans(flat, k, None, criteria, 3, cv2.KMEANS_RANDOM_CENTERS)
+        centers = centers.astype(np.float32)
+        samples_pitch.append(np.median(centers, axis=0))
+
+        # assume jerseys in top half of frame
+        jersey_region = hsv[: h // 2, :]
+        jr = jersey_region.reshape(-1, 3).astype(np.float32)
+        if jr.size:
+            k_j = min(3, len(jr))
+            _, _, centers_j = cv2.kmeans(jr, k_j, None, criteria, 3, cv2.KMEANS_RANDOM_CENTERS)
+            samples_team.append(np.median(centers_j, axis=0))
+
+    cap.release()
+
+    if samples_pitch:
+        pitch_center = np.mean(samples_pitch, axis=0)
+        config.pitch_hsv = HSVRange(h=float(pitch_center[0]), s=float(pitch_center[1]), v=float(pitch_center[2]))
+    if samples_team:
+        team_center = np.mean(samples_team, axis=0)
+        config.team_primary = HSVRange(h=float(team_center[0]), s=float(team_center[1]), v=float(team_center[2]))
+
+    logger.info(
+        "Calibrated pitch HSV=(%.1f, %.1f, %.1f) team HSV=(%.1f, %.1f, %.1f)",
+        config.pitch_hsv.h,
+        config.pitch_hsv.s,
+        config.pitch_hsv.v,
+        config.team_primary.h,
+        config.team_primary.s,
+        config.team_primary.v,
+    )
+    return config
+
+
+def mask_ratio(mask: np.ndarray) -> float:
+    return float(mask.mean() / 255.0)
+
+
+def combine_masks(masks: Iterable[np.ndarray]) -> np.ndarray:
+    result = None
+    for mask in masks:
+        if result is None:
+            result = mask.astype(np.uint8)
+        else:
+            result = cv2.bitwise_or(result, mask.astype(np.uint8))
+    return result if result is not None else np.zeros((1, 1), dtype=np.uint8)
+
+
+def pitch_mask(frame_bgr: np.ndarray, config: ColorsConfig) -> np.ndarray:
+    return hsv_mask(frame_bgr, config.pitch_hsv)
+
+
+def team_mask(frame_bgr: np.ndarray, config: ColorsConfig) -> np.ndarray:
+    return hsv_mask(frame_bgr, config.team_primary)

--- a/soccer_highlights/config.py
+++ b/soccer_highlights/config.py
@@ -1,0 +1,147 @@
+"""Configuration models and loader for the soccer highlights suite."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Optional
+
+from ._pydantic_compat import BaseModel, Field, validator
+import yaml
+
+
+class PathsConfig(BaseModel):
+    video: Path = Field(Path("full_game_stabilized.mp4"), description="Primary input video path.")
+    output_dir: Path = Field(Path("out"), description="Base directory for derived outputs.")
+    work_dir: Optional[Path] = Field(None, description="Optional cache/work directory.")
+
+
+class DetectConfig(BaseModel):
+    min_gap: float = Field(2.0, description="Minimum gap between merged segments in seconds.")
+    pre: float = Field(5.0, description="Seconds of pre-roll when expanding detections.")
+    post: float = Field(6.0, description="Seconds of post-roll when expanding detections.")
+    max_count: int = Field(40, description="Maximum number of highlight windows to keep.")
+    audio_weight: float = Field(0.5, ge=0.0, le=1.0, description="Weight of audio score in blended detection score.")
+    threshold_std: float = Field(0.5, description="Multiplier for std-dev when computing adaptive threshold.")
+    hysteresis: float = Field(0.3, description="Fraction of threshold used as low hysteresis.")
+    sustain: float = Field(1.0, description="Seconds a detection must sustain to be accepted.")
+    merge_hysteresis: float = Field(0.75, description="Merge overlapping windows when overlap exceeds this fraction.")
+
+
+class ShrinkConfig(BaseModel):
+    mode: str = Field("smart", description="Shrink mode: 'simple' or 'smart'.")
+    pre: float = Field(3.0)
+    post: float = Field(5.0)
+    aspect: str = Field("horizontal", description="Crop aspect for tracked clips.")
+    zoom: float = Field(1.2, description="Zoom factor when aspect is horizontal.")
+    bias_blue: bool = Field(False, description="Bias motion scoring toward blue jerseys.")
+    write_clips: Optional[Path] = Field(None, description="When set, tracked clips are written here.")
+
+    @validator("mode")
+    def validate_mode(cls, value: str) -> str:
+        if value not in {"simple", "smart"}:
+            raise ValueError("mode must be 'simple' or 'smart'")
+        return value
+
+    @validator("aspect")
+    def validate_aspect(cls, value: str) -> str:
+        if value not in {"horizontal", "vertical"}:
+            raise ValueError("aspect must be 'horizontal' or 'vertical'")
+        return value
+
+
+class ClipConfig(BaseModel):
+    min_duration: float = Field(3.0, description="Skip clips shorter than this.")
+    preset: str = Field("veryfast")
+    crf: int = Field(20)
+    audio_bitrate: str = Field("160k")
+    workers: int = Field(2, description="Number of parallel workers for clip export.")
+    overwrite: bool = Field(False, description="Overwrite existing clips when true.")
+
+
+class RankConfig(BaseModel):
+    k: int = Field(10, description="Number of clips to keep for Top-K.")
+    max_len: float = Field(18.0, description="Maximum duration per clip in seconds.")
+    sustain: float = Field(1.25, description="Seconds of sustained activity for inpoint selection.")
+    min_tail: float = Field(6.0, description="Minimum seconds remaining after inpoint.")
+
+
+class ReelProfile(BaseModel):
+    name: str
+    width: int
+    height: int
+    fps: float = Field(30.0)
+    crossfade_frames: int = Field(6)
+    audio_duck_db: float = Field(6.0, description="Audio ducking applied during transitions.")
+    title_duration: float = Field(1.0, description="Seconds for intro title slate.")
+    label_position: str = Field("0.05*W:0.1*H", description="drawtext position expression.")
+
+
+class ReelConfig(BaseModel):
+    profile: str = Field("broadcast")
+    topk_title: str = Field("Top Plays")
+    full_title: str = Field("Full Highlights")
+
+
+class HSVRange(BaseModel):
+    h: float
+    s: float
+    v: float
+
+
+class ColorsConfig(BaseModel):
+    pitch_hsv: HSVRange = Field(HSVRange(h=90, s=80, v=80))
+    team_primary: HSVRange = Field(HSVRange(h=210, s=70, v=70))
+    team_secondary: HSVRange = Field(HSVRange(h=30, s=70, v=70))
+    calibrate: bool = Field(False)
+
+
+class AppConfig(BaseModel):
+    paths: PathsConfig = Field(default_factory=PathsConfig)
+    detect: DetectConfig = Field(default_factory=DetectConfig)
+    shrink: ShrinkConfig = Field(default_factory=ShrinkConfig)
+    clips: ClipConfig = Field(default_factory=ClipConfig)
+    rank: RankConfig = Field(default_factory=RankConfig)
+    reels: ReelConfig = Field(default_factory=ReelConfig)
+    colors: ColorsConfig = Field(default_factory=ColorsConfig)
+    profiles: Dict[str, ReelProfile] = Field(
+        default_factory=lambda: {
+            "broadcast": ReelProfile(name="broadcast", width=1920, height=1080, fps=30.0, crossfade_frames=6),
+            "social-vertical": ReelProfile(
+                name="social-vertical",
+                width=1080,
+                height=1920,
+                fps=30.0,
+                crossfade_frames=8,
+                audio_duck_db=8.0,
+                label_position="0.08*W:0.12*H",
+            ),
+            "coach-review": ReelProfile(
+                name="coach-review",
+                width=1280,
+                height=720,
+                fps=30.0,
+                crossfade_frames=4,
+                audio_duck_db=4.0,
+                label_position="0.05*W:0.05*H",
+            ),
+        }
+    )
+
+    def resolve_profile(self, name: Optional[str] = None) -> ReelProfile:
+        target = name or self.reels.profile
+        if target not in self.profiles:
+            raise KeyError(f"Unknown reel profile '{target}'. Available: {sorted(self.profiles)}")
+        return self.profiles[target]
+
+    @property
+    def output_dir(self) -> Path:
+        return self.paths.output_dir
+
+
+def load_config(path: Path | str) -> AppConfig:
+    """Load configuration from YAML, falling back to defaults when missing."""
+
+    cfg_path = Path(path)
+    if not cfg_path.exists():
+        return AppConfig()
+    data = yaml.safe_load(cfg_path.read_text()) or {}
+    return AppConfig.parse_obj(data)

--- a/soccer_highlights/detect.py
+++ b/soccer_highlights/detect.py
@@ -1,0 +1,180 @@
+"""Scene and event detection combining motion and audio."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+import cv2
+import numpy as np
+from ._loguru import logger
+from ._tqdm import tqdm
+from dataclasses import dataclass
+
+from .config import AppConfig
+from .io import video_stream_info
+from .utils import HighlightWindow, merge_overlaps, summary_stats, write_highlights
+
+
+@dataclass
+class DetectionOutput:
+    windows: List[HighlightWindow]
+    adaptive_threshold: float
+    low_threshold: float
+    mean_score: float
+    std_score: float
+
+
+def _compute_audio_scores(video_path: Path, target_rate: int = 1) -> np.ndarray:
+    try:
+        import librosa
+    except Exception as exc:
+        logger.warning("librosa unavailable (%s); audio scores disabled", exc)
+        return np.zeros(0, dtype=np.float32)
+
+    try:
+        y, sr = librosa.load(video_path, sr=None, mono=True)
+    except Exception as exc:
+        logger.warning("Failed to load audio: %s", exc)
+        return np.zeros(0, dtype=np.float32)
+    hop = sr // target_rate
+    hop = max(1, hop)
+    rms = librosa.feature.rms(y=y, frame_length=sr, hop_length=hop)[0]
+    if rms.size == 0:
+        return np.zeros(0, dtype=np.float32)
+    return rms.astype(np.float32)
+
+
+def _compute_motion_scores(video_path: Path, fps: float) -> np.ndarray:
+    cap = cv2.VideoCapture(str(video_path))
+    if not cap.isOpened():
+        logger.error("Could not open video %s", video_path)
+        return np.zeros(0, dtype=np.float32)
+    frames_per_bin = max(1, int(round(fps)))
+    ok, prev = cap.read()
+    if not ok:
+        cap.release()
+        return np.zeros(0, dtype=np.float32)
+    prev = cv2.cvtColor(prev, cv2.COLOR_BGR2GRAY)
+    flow_acc: List[float] = []
+    accum = 0.0
+    count = 0
+    total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT) or 0)
+    with tqdm(total=max(total_frames - 1, 0), desc="motion", unit="frame", leave=False) as bar:
+        while True:
+            ok, frame = cap.read()
+            if not ok:
+                break
+            gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+            flow = cv2.calcOpticalFlowFarneback(prev, gray, None, 0.5, 3, 15, 3, 5, 1.2, 0)
+            mag = np.linalg.norm(flow, axis=2).sum()
+            accum += float(mag)
+            count += 1
+            bar.update(1)
+            if count == frames_per_bin:
+                flow_acc.append(accum)
+                accum = 0.0
+                count = 0
+            prev = gray
+    if count:
+        flow_acc.append(accum)
+    cap.release()
+    if not flow_acc:
+        return np.zeros(0, dtype=np.float32)
+    arr = np.array(flow_acc, dtype=np.float32)
+    return arr
+
+
+def _normalize(arr: np.ndarray) -> np.ndarray:
+    if arr.size == 0:
+        return arr
+    arr = arr.astype(np.float32)
+    arr = arr - arr.min()
+    maxv = arr.max()
+    if maxv > 1e-6:
+        arr = arr / maxv
+    return arr
+
+
+def _expand_window(idx_start: int, idx_end: int, pre: float, post: float, total_duration: float) -> tuple[float, float]:
+    start_time = max(0.0, idx_start - pre)
+    end_time = (idx_end + 1) + post
+    end_time = min(total_duration, end_time)
+    return start_time, end_time
+
+
+def detect_highlights(config: AppConfig, video_path: Path, output_csv: Path) -> DetectionOutput:
+    info = video_stream_info(video_path)
+    logger.info("Detecting highlights from %s (fps=%.2f, duration=%.2fs)", video_path, info.fps, info.duration)
+
+    motion = _compute_motion_scores(video_path, info.fps)
+    audio = _compute_audio_scores(video_path)
+
+    n = max(len(motion), len(audio))
+    if n == 0:
+        logger.warning("No frames or audio samples found; nothing to detect")
+        return DetectionOutput([], 0.0, 0.0, 0.0, 0.0)
+    motion = np.pad(motion, (0, max(0, n - len(motion))), constant_values=0.0)
+    audio = np.pad(audio, (0, max(0, n - len(audio))), constant_values=0.0)
+
+    motion = _normalize(motion)
+    audio = _normalize(audio)
+    w = config.detect.audio_weight
+    scores = (1.0 - w) * motion + w * audio
+
+    mean_score = float(scores.mean())
+    std_score = float(scores.std())
+    adaptive_thr = mean_score + std_score * config.detect.threshold_std
+    low_thr = adaptive_thr * (1.0 - config.detect.hysteresis)
+    sustain_frames = max(1, int(round(config.detect.sustain)))
+
+    logger.info(
+        "Adaptive threshold %.3f (low %.3f) mean %.3f std %.3f", adaptive_thr, low_thr, mean_score, std_score
+    )
+
+    windows: List[HighlightWindow] = []
+    idx = 0
+    while idx < n:
+        if scores[idx] >= adaptive_thr:
+            # verify sustain
+            sustain_ok = True
+            for j in range(idx, min(idx + sustain_frames, n)):
+                if scores[j] < adaptive_thr:
+                    sustain_ok = False
+                    break
+            if not sustain_ok:
+                idx += 1
+                continue
+            peak_score = float(scores[idx])
+            start_idx = idx
+            idx += 1
+            while idx < n and scores[idx] >= low_thr:
+                peak_score = max(peak_score, float(scores[idx]))
+                idx += 1
+            end_idx = max(idx - 1, start_idx)
+            start_sec, end_sec = _expand_window(start_idx, end_idx, config.detect.pre, config.detect.post, info.duration)
+            windows.append(HighlightWindow(start=start_sec, end=end_sec, score=peak_score, event="scene"))
+        else:
+            idx += 1
+
+    merged = merge_overlaps(windows, config.detect.min_gap)
+    merged.sort(key=lambda w: w.score, reverse=True)
+    if config.detect.max_count:
+        merged = merged[: config.detect.max_count]
+    merged.sort(key=lambda w: w.start)
+
+    stats = summary_stats(merged)
+    logger.info("Detected %d windows", stats["count"])
+
+    return DetectionOutput(
+        windows=merged,
+        adaptive_threshold=adaptive_thr,
+        low_threshold=low_thr,
+        mean_score=mean_score,
+        std_score=std_score,
+    )
+
+
+def run_detect(config: AppConfig, video_path: Path, output_csv: Path) -> DetectionOutput:
+    result = detect_highlights(config, video_path, output_csv)
+    write_highlights(output_csv, result.windows)
+    return result

--- a/soccer_highlights/io.py
+++ b/soccer_highlights/io.py
@@ -1,0 +1,108 @@
+"""Video/audio IO helpers built on ffmpeg/ffprobe."""
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from fractions import Fraction
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Sequence
+
+from ._loguru import logger
+
+
+@dataclass
+class VideoStreamInfo:
+    path: Path
+    duration: float
+    fps: float
+    width: int
+    height: int
+    time_base: Fraction
+
+
+@dataclass
+class AudioStreamInfo:
+    path: Path
+    duration: float
+    sample_rate: int
+    channels: int
+
+
+class FFmpegError(RuntimeError):
+    pass
+
+
+def run_command(cmd: Sequence[str], *, check: bool = True) -> subprocess.CompletedProcess:
+    """Run a subprocess command logging the invocation."""
+
+    logger.debug("Running command: {}", " ".join(cmd))
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if check and result.returncode != 0:
+        raise FFmpegError(f"Command failed with code {result.returncode}: {' '.join(cmd)}\n{result.stderr}")
+    if result.stderr:
+        logger.debug(result.stderr.strip())
+    return result
+
+
+def ffprobe_json(path: Path) -> Dict[str, Any]:
+    cmd = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-print_format",
+        "json",
+        "-show_format",
+        "-show_streams",
+        str(path),
+    ]
+    result = run_command(cmd)
+    if result.stdout:
+        return json.loads(result.stdout)
+    raise FFmpegError(f"ffprobe produced no output for {path}")
+
+
+def _parse_fraction(value: str) -> Fraction:
+    num, _, den = value.partition("/")
+    if den:
+        return Fraction(int(num), int(den))
+    return Fraction(float(value)).limit_denominator()
+
+
+def video_stream_info(path: Path) -> VideoStreamInfo:
+    data = ffprobe_json(path)
+    streams = [s for s in data.get("streams", []) if s.get("codec_type") == "video"]
+    if not streams:
+        raise FFmpegError(f"No video streams found in {path}")
+    stream = streams[0]
+    duration = float(stream.get("duration") or data["format"].get("duration") or 0.0)
+    width = int(stream.get("width"))
+    height = int(stream.get("height"))
+    r_frame_rate = stream.get("r_frame_rate", "0/0")
+    fps = float(Fraction(r_frame_rate)) if "0/0" not in r_frame_rate else float(stream.get("avg_frame_rate", 0.0))
+    time_base = _parse_fraction(stream.get("time_base", "1/1"))
+    return VideoStreamInfo(path=path, duration=duration, fps=fps, width=width, height=height, time_base=time_base)
+
+
+def audio_stream_info(path: Path) -> AudioStreamInfo:
+    data = ffprobe_json(path)
+    streams = [s for s in data.get("streams", []) if s.get("codec_type") == "audio"]
+    if not streams:
+        raise FFmpegError(f"No audio streams found in {path}")
+    stream = streams[0]
+    duration = float(stream.get("duration") or data["format"].get("duration") or 0.0)
+    sample_rate = int(stream.get("sample_rate", 48000))
+    channels = int(stream.get("channels", 2))
+    return AudioStreamInfo(path=path, duration=duration, sample_rate=sample_rate, channels=channels)
+
+
+def ensure_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def seconds_to_timestamp(value: float) -> str:
+    return f"{value:.3f}"
+
+
+def list_from_paths(paths: Iterable[Path]) -> List[str]:
+    return [str(p) for p in paths]

--- a/soccer_highlights/rank.py
+++ b/soccer_highlights/rank.py
@@ -1,0 +1,153 @@
+"""Rank candidate clips and produce Top-K lists."""
+from __future__ import annotations
+
+import csv
+import glob
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+import cv2
+import numpy as np
+from ._loguru import logger
+
+from .config import AppConfig
+
+
+@dataclass
+class RankedClip:
+    path: Path
+    inpoint: float
+    duration: float
+    motion: float
+    audio: float
+    score: float
+
+
+def _activity_profile(path: Path, sample_fps: int = 6) -> tuple[List[float], np.ndarray, np.ndarray]:
+    cap = cv2.VideoCapture(str(path))
+    fps = cap.get(cv2.CAP_PROP_FPS) or 24.0
+    stride = max(1, int(round(fps / sample_fps)))
+    ok, prev = cap.read()
+    if not ok:
+        cap.release()
+        return [], np.zeros(0), np.zeros(0)
+    prev = cv2.cvtColor(prev, cv2.COLOR_BGR2GRAY)
+    times: List[float] = []
+    cover: List[float] = []
+    mag: List[float] = []
+    while True:
+        for _ in range(stride - 1):
+            if not cap.grab():
+                break
+        ok, frame = cap.read()
+        if not ok:
+            break
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        diff = cv2.absdiff(gray, prev)
+        prev = gray
+        m = float(diff.mean()) / 255.0
+        mask = (diff > 10).astype(np.uint8)
+        c = float(mask.mean())
+        t = cap.get(cv2.CAP_PROP_POS_MSEC) / 1000.0
+        times.append(t)
+        cover.append(c)
+        mag.append(m)
+    cap.release()
+    return times, np.array(cover), np.array(mag)
+
+
+def _find_first_active(times: List[float], cover: np.ndarray, mag: np.ndarray, sustain_sec: float, sample_fps: int = 6) -> float:
+    if not times:
+        return 0.0
+    cov_base = np.percentile(cover, 20) if cover.size else 0.0
+    cov_thr = max(0.01, cov_base + 0.01)
+    mag_thr = max(0.01, np.percentile(mag, 20) + 0.005) if mag.size else 0.01
+    active = (cover > cov_thr) & (mag > mag_thr)
+    need = max(1, int(round(sustain_sec * sample_fps)))
+    run = 0
+    for idx, flag in enumerate(active):
+        run = run + 1 if flag else 0
+        if run >= need:
+            return max(0.0, times[idx] - 1.0)
+    return 0.0
+
+
+def _audio_rms(path: Path) -> float:
+    try:
+        import librosa
+    except Exception:
+        return 0.0
+    try:
+        y, sr = librosa.load(path, sr=None, mono=True)
+    except Exception:
+        return 0.0
+    rms = librosa.feature.rms(y=y, frame_length=2048, hop_length=512).ravel()
+    if rms.size == 0:
+        return 0.0
+    return float(np.percentile(rms, 90))
+
+
+def _clip_duration(path: Path) -> float:
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        return 0.0
+    fps = cap.get(cv2.CAP_PROP_FPS) or 24.0
+    frames = cap.get(cv2.CAP_PROP_FRAME_COUNT) or 0
+    cap.release()
+    return float(frames / fps) if frames else 0.0
+
+
+def score_clip(path: Path, sustain_sec: float) -> RankedClip:
+    times, cover, mag = _activity_profile(path)
+    inpoint = _find_first_active(times, cover, mag, sustain_sec)
+    motion_score = float(np.percentile(mag[cover > 0] if cover.size and (cover > 0).any() else mag, 80)) if mag.size else 0.0
+    audio_score = _audio_rms(path)
+    duration = _clip_duration(path)
+    score = 0.65 * motion_score + 0.35 * audio_score
+    return RankedClip(path=path, inpoint=round(inpoint, 3), duration=duration, motion=motion_score, audio=audio_score, score=score)
+
+
+def _candidate_files(paths: Iterable[Path]) -> List[Path]:
+    files: List[Path] = []
+    for directory in paths:
+        pattern = str(directory / "clip_*.mp4")
+        files.extend(Path(f) for f in sorted(glob.glob(pattern)))
+    return files
+
+
+def write_rankings(csv_path: Path, clips: List[RankedClip]) -> None:
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    with csv_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["path", "inpoint", "duration", "motion", "audio", "score"])
+        for clip in clips:
+            writer.writerow([clip.path.as_posix(), f"{clip.inpoint:.3f}", f"{clip.duration:.3f}", f"{clip.motion:.4f}", f"{clip.audio:.4f}", f"{clip.score:.4f}"])
+
+
+def write_concat(list_path: Path, clips: List[RankedClip], max_len: float) -> None:
+    list_path.parent.mkdir(parents=True, exist_ok=True)
+    with list_path.open("w", newline="\n", encoding="utf-8") as f:
+        for clip in clips:
+            outpoint = min(clip.duration, clip.inpoint + max_len)
+            f.write(f"file '{clip.path.as_posix()}'\n")
+            f.write(f"inpoint {clip.inpoint:.3f}\n")
+            f.write(f"outpoint {outpoint:.3f}\n")
+
+
+def run_topk(config: AppConfig, candidate_dirs: List[Path], csv_out: Path, concat_out: Path, k: int | None = None, max_len: float | None = None) -> List[RankedClip]:
+    k = k or config.rank.k
+    max_len = max_len or config.rank.max_len
+    files = _candidate_files(candidate_dirs)
+    if not files:
+        logger.warning("No candidate clips found in %s", candidate_dirs)
+        return []
+    scored = [score_clip(path, config.rank.sustain) for path in files]
+    filtered = [clip for clip in scored if clip.duration - clip.inpoint >= config.rank.min_tail]
+    if len(filtered) < k:
+        filtered = scored
+    ranked = sorted(filtered, key=lambda c: c.score, reverse=True)[:k]
+    write_rankings(csv_out, ranked)
+    write_concat(concat_out, ranked, max_len)
+    logger.info("Wrote %s and %s", csv_out, concat_out)
+    return ranked

--- a/soccer_highlights/reels.py
+++ b/soccer_highlights/reels.py
@@ -1,0 +1,150 @@
+"""Render highlight reels with transitions and slates."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+from ._loguru import logger
+
+from .config import AppConfig
+from .io import run_command
+
+
+@dataclass
+class ReelEntry:
+    path: Path
+    inpoint: float
+    outpoint: float
+
+    @property
+    def duration(self) -> float:
+        return max(0.0, self.outpoint - self.inpoint)
+
+
+def _escape_drawtext(text: str) -> str:
+    return text.replace("\\", "\\\\").replace(":", "\\:").replace("'", "\\\\'")
+
+
+def _parse_concat(list_path: Path) -> List[ReelEntry]:
+    entries: List[ReelEntry] = []
+    current = {}
+    for line in list_path.read_text().splitlines():
+        line = line.strip()
+        if line.startswith("file"):
+            path = line.split(" ", 1)[1].strip().strip("'")
+            current["path"] = Path(path)
+        elif line.startswith("inpoint"):
+            current["inpoint"] = float(line.split()[1])
+        elif line.startswith("outpoint"):
+            current["outpoint"] = float(line.split()[1])
+            entries.append(ReelEntry(path=current["path"], inpoint=current.get("inpoint", 0.0), outpoint=current.get("outpoint", 0.0)))
+            current = {}
+    return entries
+
+
+def render_reel(config: AppConfig, list_path: Path, output_path: Path, title: str, profile_name: str | None = None) -> float:
+    entries = _parse_concat(list_path)
+    if not entries:
+        logger.warning("No entries in concat list %s", list_path)
+        return 0.0
+    profile = config.resolve_profile(profile_name)
+    crossfade = profile.crossfade_frames / profile.fps
+    title_duration = profile.title_duration
+    drawtext_title = _escape_drawtext(title)
+    cmd: List[str] = ["ffmpeg", "-hide_banner", "-y"]
+    cmd += [
+        "-f",
+        "lavfi",
+        "-i",
+        f"color=c=black:size={profile.width}x{profile.height}:duration={title_duration:.3f}",
+        "-f",
+        "lavfi",
+        "-i",
+        f"anullsrc=r=48000:cl=stereo:d={title_duration:.3f}",
+    ]
+    for entry in entries:
+        cmd += ["-i", str(entry.path)]
+
+    filters: List[str] = []
+    filters.append(
+        f"[0:v]drawtext=text='{drawtext_title}':x=(w-text_w)/2:y=(h-text_h)/2:fontcolor=white:fontsize=72:borderw=2,format=yuv420p[vtitle]"
+    )
+    filters.append(f"[1:a]anull[audtitle]")
+
+    video_labels = ["vtitle"]
+    audio_labels = ["audtitle"]
+    durations = [title_duration]
+
+    label_expr = profile.label_position.replace("W", "w").replace("H", "h")
+
+    for idx, entry in enumerate(entries, start=1):
+        input_idx = idx + 1  # accounts for title video/audio inputs
+        number_text = _escape_drawtext(f"#{idx}")
+        filters.append(
+            f"[{input_idx}:v]trim=start={entry.inpoint:.3f}:end={entry.outpoint:.3f},setpts=PTS-STARTPTS,"
+            f"scale=w={profile.width}:h={profile.height}:force_original_aspect_ratio=decrease,"
+            f"pad={profile.width}:{profile.height}:(ow-iw)/2:(oh-ih)/2:black,setsar=1,format=yuv420p,"
+            f"drawtext=text='{number_text}':x={label_expr.split(':')[0]}:y={label_expr.split(':')[1]}:fontcolor=white:fontsize=64:borderw=2[v{idx}]"
+        )
+        filters.append(
+            f"[{input_idx}:a]atrim=start={entry.inpoint:.3f}:end={entry.outpoint:.3f},asetpts=PTS-STARTPTS,alimiter=limit=0.9[a{idx}]"
+        )
+        video_labels.append(f"v{idx}")
+        audio_labels.append(f"a{idx}")
+        durations.append(entry.duration)
+
+    current_v = video_labels[0]
+    current_a = audio_labels[0]
+    timeline = durations[0]
+    for idx in range(1, len(video_labels)):
+        src_v = video_labels[idx]
+        src_a = audio_labels[idx]
+        out_v = f"vmix{idx}"
+        out_a = f"amix{idx}"
+        prev_dur = durations[idx - 1]
+        curr_dur = durations[idx]
+        cf = min(crossfade, prev_dur / 2.0, curr_dur / 2.0) if crossfade > 0 else 0.0
+        if cf < 1e-3:
+            cf = 1e-3
+        offset = max(timeline - cf, 0.0)
+        filters.append(
+            f"[{current_v}][{src_v}]xfade=transition=fade:duration={cf:.3f}:offset={offset:.3f}[{out_v}]"
+        )
+        filters.append(
+            f"[{current_a}][{src_a}]acrossfade=d={cf:.3f}:curve1=tri:curve2=tri[{out_a}]"
+        )
+        current_v = out_v
+        current_a = out_a
+        timeline += curr_dur - cf
+
+    filters.append(f"[{current_a}]volume=1.0[aout]")
+    filters.append(f"[{current_v}]format=yuv420p[vout]")
+
+    cmd += [
+        "-filter_complex",
+        ";".join(filters),
+        "-map",
+        "[vout]",
+        "-map",
+        "[aout]",
+        "-r",
+        f"{profile.fps}",
+        "-c:v",
+        "libx264",
+        "-preset",
+        config.clips.preset,
+        "-crf",
+        str(config.clips.crf),
+        "-c:a",
+        "aac",
+        "-b:a",
+        config.clips.audio_bitrate,
+        "-movflags",
+        "+faststart",
+        str(output_path),
+    ]
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    run_command(cmd)
+    logger.info("Rendered reel to %s", output_path)
+    return timeline

--- a/soccer_highlights/shrink.py
+++ b/soccer_highlights/shrink.py
@@ -1,0 +1,207 @@
+"""Refine highlight windows around motion/audio peaks."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+import cv2
+import numpy as np
+from ._loguru import logger
+from ._tqdm import tqdm
+
+from .config import AppConfig
+from .colors import calibrate_colors, hsv_mask
+from .io import video_stream_info
+from .utils import HighlightWindow, clamp, read_highlights, trim_to_duration, write_highlights
+
+
+def _audio_envelope(video_path: Path) -> tuple[Optional[np.ndarray], Optional[np.ndarray]]:
+    try:
+        import librosa
+    except Exception as exc:
+        logger.warning("librosa unavailable (%s); audio guidance disabled", exc)
+        return None, None
+    try:
+        y, sr = librosa.load(video_path, sr=None, mono=True)
+    except Exception as exc:
+        logger.warning("Failed to load audio for envelope: %s", exc)
+        return None, None
+    hop = 512
+    env = librosa.onset.onset_strength(y=y, sr=sr, hop_length=hop).astype(np.float32)
+    t = librosa.frames_to_time(np.arange(len(env)), sr=sr, hop_length=hop)
+    if env.size:
+        env = (env - env.min()) / (env.max() - env.min() + 1e-8)
+    return t, env
+
+
+def _motion_timeseries(cap: cv2.VideoCapture, f0: int, f1: int, use_mask: Optional[np.ndarray] = None) -> tuple[np.ndarray, np.ndarray]:
+    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    cap.set(cv2.CAP_PROP_POS_FRAMES, f0)
+    ok, prev = cap.read()
+    if not ok:
+        return np.zeros(0, dtype=np.float32), np.zeros(0, dtype=np.float32)
+    prev_small = cv2.resize(prev, (0, 0), fx=0.5, fy=0.5)
+    prev_gray = cv2.GaussianBlur(cv2.cvtColor(prev_small, cv2.COLOR_BGR2GRAY), (5, 5), 0)
+    energies: List[float] = []
+    times: List[float] = []
+
+    for frame_idx in range(f0 + 1, f1):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        sm = cv2.resize(frame, (prev_small.shape[1], prev_small.shape[0]))
+        gray = cv2.GaussianBlur(cv2.cvtColor(sm, cv2.COLOR_BGR2GRAY), (5, 5), 0)
+        diff = cv2.absdiff(gray, prev_gray).astype(np.float32)
+        base = float(diff.sum())
+        if use_mask is not None:
+            mask_resized = cv2.resize(use_mask, (sm.shape[1], sm.shape[0]))
+            weighted = float((diff * (mask_resized / 255.0)).sum())
+            energy = 0.65 * base + 0.35 * weighted
+        else:
+            energy = base
+        energies.append(energy)
+        times.append(frame_idx / fps)
+        prev_gray = gray
+    if not energies:
+        return np.zeros(0, dtype=np.float32), np.zeros(0, dtype=np.float32)
+    arr = np.array(energies, dtype=np.float32)
+    ker = np.ones(9, np.float32) / 9.0
+    arr = np.convolve(arr, ker, mode="same")
+    if arr.max() > 0:
+        arr = (arr - arr.min()) / (arr.max() - arr.min() + 1e-8)
+    return arr, np.array(times, dtype=np.float32)
+
+
+def _find_peak(cap: cv2.VideoCapture, win: HighlightWindow, audio_t: Optional[np.ndarray], audio_env: Optional[np.ndarray],
+               use_mask: Optional[np.ndarray], total_frames: int) -> float:
+    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    start_frame = clamp(int(win.start * fps), 0, max(total_frames - 2, 0))
+    end_frame = clamp(int(win.end * fps), start_frame + 1, max(total_frames - 1, start_frame + 1))
+    motion, times = _motion_timeseries(cap, start_frame, end_frame, use_mask)
+    if motion.size == 0 or times.size == 0:
+        return (win.start + win.end) / 2.0
+    score = motion.copy()
+    if audio_t is not None and audio_env is not None and audio_env.size:
+        interp = np.interp(times, audio_t, audio_env)
+        interp = (interp - interp.min()) / (interp.max() - interp.min() + 1e-8)
+        score = 0.75 * score + 0.25 * interp
+    idx = int(np.argmax(score))
+    return float(times[idx])
+
+
+def _tracked_frames(cap: cv2.VideoCapture, f0: int, f1: int) -> Iterable[np.ndarray]:
+    cap.set(cv2.CAP_PROP_POS_FRAMES, f0)
+    for _ in range(f0, f1):
+        ok, frame = cap.read()
+        if not ok:
+            break
+        yield frame
+
+
+def _tracked_writer(out_path: Path, frames: Iterable[np.ndarray], width: int, height: int, aspect: str, zoom: float, fps: float) -> None:
+    if aspect == "vertical":
+        out_w, out_h = 1080, 1920
+        crop_h = height
+        crop_w = min(width, int(round(crop_h * 9 / 16)))
+    else:
+        out_w, out_h = 1920, 1080
+        crop_w = max(640, min(width, int(round(width / zoom))))
+        crop_h = max(360, min(height, int(round(height / zoom))))
+    writer = cv2.VideoWriter(str(out_path), cv2.VideoWriter_fourcc(*"mp4v"), fps, (out_w, out_h))
+    if not writer.isOpened():
+        raise RuntimeError(f"Could not open {out_path} for writing")
+    cx, cy = width // 2, height // 2
+    alpha = 0.12
+    sw, sh = width // 2, height // 2
+    prev_small = None
+    for frame in frames:
+        small = cv2.resize(frame, (sw, sh))
+        gray = cv2.GaussianBlur(cv2.cvtColor(small, cv2.COLOR_BGR2GRAY), (5, 5), 0)
+        if prev_small is None:
+            prev_small = gray
+        diff = cv2.absdiff(gray, prev_small)
+        prev_small = gray
+        thr = max(10, int(diff.mean() + 2 * diff.std()))
+        _, mask = cv2.threshold(diff, thr, 255, cv2.THRESH_BINARY)
+        mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, np.ones((5, 5), np.uint8))
+        mask = cv2.dilate(mask, np.ones((7, 7), np.uint8), iterations=1)
+        ys, xs = np.where(mask > 0)
+        if xs.size:
+            cx_s = np.mean(xs)
+            cy_s = np.mean(ys)
+            cx = int((1 - alpha) * cx + alpha * (cx_s * (width / float(sw))))
+            cy = int((1 - alpha) * cy + alpha * (cy_s * (height / float(sh))))
+        else:
+            cx = int((1 - alpha) * cx + alpha * (width // 2))
+            cy = int((1 - alpha) * cy + alpha * (height // 2))
+        x0 = int(round(cx - crop_w / 2))
+        y0 = int(round(cy - crop_h / 2))
+        x0 = int(clamp(x0, 0, width - crop_w))
+        y0 = int(clamp(y0, 0, height - crop_h))
+        crop = frame[y0 : y0 + crop_h, x0 : x0 + crop_w]
+        resized = cv2.resize(crop, (out_w, out_h), interpolation=cv2.INTER_CUBIC)
+        writer.write(resized)
+    writer.release()
+
+
+def smart_shrink(config: AppConfig, video_path: Path, windows: List[HighlightWindow]) -> List[HighlightWindow]:
+    cap = cv2.VideoCapture(str(video_path))
+    if not cap.isOpened():
+        raise RuntimeError(f"Could not open {video_path}")
+    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+    total_dur = cap.get(cv2.CAP_PROP_FRAME_COUNT) / fps if fps else 0.0
+    audio_t, audio_env = _audio_envelope(video_path)
+    colors = config.colors
+    if colors.calibrate:
+        colors = calibrate_colors(str(video_path), colors)
+        config.colors = colors
+    mask = None
+    if config.shrink.bias_blue:
+        cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
+        ok, frame = cap.read()
+        if ok:
+            mask = hsv_mask(frame, colors.team_primary)
+    refined: List[HighlightWindow] = []
+    tracker_out = config.shrink.write_clips
+    if tracker_out:
+        Path(tracker_out).mkdir(parents=True, exist_ok=True)
+    for idx, win in enumerate(tqdm(windows, desc="shrink", unit="clip", leave=False), start=1):
+        peak = _find_peak(cap, win, audio_t, audio_env, mask, total_frames)
+        rs = clamp(peak - config.shrink.pre, 0.0, total_dur)
+        re = clamp(peak + config.shrink.post, 0.0, total_dur)
+        if re <= rs + 0.1:
+            re = clamp(rs + 0.1, 0.0, total_dur)
+        refined.append(HighlightWindow(start=rs, end=re, score=win.score, event=win.event))
+        if tracker_out:
+            start_frame = int(rs * fps)
+            end_frame = min(total_frames - 1, int(re * fps))
+            frames = list(_tracked_frames(cap, start_frame, end_frame))
+            if frames:
+                out_path = Path(tracker_out) / f"clip_{idx:04d}.mp4"
+                _tracked_writer(out_path, frames, int(cap.get(cv2.CAP_PROP_FRAME_WIDTH)), int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT)), config.shrink.aspect, config.shrink.zoom, fps)
+                logger.info("Tracked clip %s", out_path)
+    cap.release()
+    return refined
+
+
+def simple_shrink(config: AppConfig, video_path: Path, windows: List[HighlightWindow]) -> List[HighlightWindow]:
+    info = video_stream_info(Path(video_path))
+    refined: List[HighlightWindow] = []
+    for win in windows:
+        start, end = trim_to_duration(win.start, win.end, config.shrink.pre, config.shrink.post, info.duration)
+        refined.append(HighlightWindow(start=start, end=end, score=win.score, event=win.event))
+    return refined
+
+
+def run_shrink(config: AppConfig, video_path: Path, csv_in: Path, csv_out: Path) -> List[HighlightWindow]:
+    windows = read_highlights(csv_in)
+    if not windows:
+        logger.warning("No input windows found in %s", csv_in)
+        return []
+    if config.shrink.mode == "simple":
+        refined = simple_shrink(config, video_path, windows)
+    else:
+        refined = smart_shrink(config, video_path, windows)
+    write_highlights(csv_out, refined)
+    return refined

--- a/soccer_highlights/utils.py
+++ b/soccer_highlights/utils.py
@@ -1,0 +1,133 @@
+"""Utility helpers used across pipeline stages."""
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import mean, median
+from typing import Iterable, List, Sequence
+
+from ._loguru import logger
+
+
+@dataclass
+class HighlightWindow:
+    start: float
+    end: float
+    score: float
+    event: str = "scene"
+
+    def duration(self) -> float:
+        return max(0.0, self.end - self.start)
+
+
+def read_highlights(csv_path: Path) -> List[HighlightWindow]:
+    rows: List[HighlightWindow] = []
+    with csv_path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            rows.append(
+                HighlightWindow(
+                    start=float(row.get("start", 0.0)),
+                    end=float(row.get("end", 0.0)),
+                    score=float(row.get("score", 0.0)),
+                    event=row.get("event", "scene"),
+                )
+            )
+    return rows
+
+
+def write_highlights(csv_path: Path, windows: Sequence[HighlightWindow]) -> None:
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    with csv_path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["start", "end", "score", "event"])
+        for w in windows:
+            writer.writerow([f"{w.start:.3f}", f"{w.end:.3f}", f"{w.score:.4f}", w.event])
+
+
+def merge_overlaps(windows: Sequence[HighlightWindow], min_gap: float) -> List[HighlightWindow]:
+    if not windows:
+        return []
+    ordered = sorted(windows, key=lambda w: w.start)
+    merged: List[HighlightWindow] = [ordered[0]]
+    for win in ordered[1:]:
+        last = merged[-1]
+        if win.start - last.end <= min_gap:
+            new_end = max(last.end, win.end)
+            new_score = max(last.score, win.score)
+            merged[-1] = HighlightWindow(start=last.start, end=new_end, score=new_score, event=last.event)
+        else:
+            merged.append(win)
+    return merged
+
+
+def clamp(value: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, value))
+
+
+@dataclass
+class PipelineReport:
+    path: Path
+    data: dict
+
+    def update(self, section: str, payload: dict) -> None:
+        self.data[section] = payload
+        self.write()
+
+    def write(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(self.data, indent=2))
+        write_report_md(self.path.with_suffix(".md"), self.data)
+
+
+def load_report(base_dir: Path) -> PipelineReport:
+    json_path = base_dir / "report.json"
+    if json_path.exists():
+        data = json.loads(json_path.read_text())
+    else:
+        data = {}
+    return PipelineReport(path=json_path, data=data)
+
+
+def write_report_md(path: Path, data: dict) -> None:
+    lines = ["# Soccer Highlights Report", ""]
+    if not data:
+        lines.append("No pipeline runs recorded yet.")
+    else:
+        for section, payload in data.items():
+            lines.append(f"## {section.title()}")
+            for key, value in payload.items():
+                lines.append(f"- **{key.replace('_', ' ').title()}**: {value}")
+            lines.append("")
+    path.write_text("\n".join(lines))
+
+
+def summary_stats(windows: Sequence[HighlightWindow]) -> dict:
+    if not windows:
+        return {"count": 0, "mean_duration": 0.0, "median_duration": 0.0}
+    durations = [w.duration() for w in windows]
+    return {
+        "count": len(windows),
+        "mean_duration": round(mean(durations), 3),
+        "median_duration": round(median(durations), 3),
+    }
+
+
+def trim_to_duration(start: float, end: float, pre: float, post: float, bounds: float) -> tuple[float, float]:
+    center = (start + end) / 2.0
+    new_start = clamp(center - pre, 0.0, bounds)
+    new_end = clamp(center + post, 0.0, bounds)
+    if new_end <= new_start:
+        new_end = clamp(new_start + 0.1, 0.0, bounds)
+    return new_start, new_end
+
+
+def safe_remove(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        logger.warning("Failed to remove %s: %s", path, exc)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import shutil
+
+import pytest
+
+if shutil.which('ffmpeg') is None:
+    pytest.skip('ffmpeg required for pipeline test', allow_module_level=True)
+
+try:
+    import cv2  # type: ignore
+    import numpy  # type: ignore # noqa: F401
+except Exception:
+    pytest.skip('OpenCV and numpy are required for the pipeline test', allow_module_level=True)
+
+from soccer_highlights.cli import main
+from examples.generate_sample import main as generate_sample
+
+
+@pytest.mark.slow
+def test_end_to_end(tmp_path: Path) -> None:
+    video_path = tmp_path / "sample.mp4"
+    generate_sample(video_path)
+    output_dir = tmp_path / "out"
+    config_path = tmp_path / "config.yaml"
+    config = {
+        "paths": {"video": str(video_path), "output_dir": str(output_dir)},
+        "detect": {"pre": 2.0, "post": 3.0, "min_gap": 1.0, "max_count": 10, "audio_weight": 0.0, "threshold_std": 0.3, "hysteresis": 0.25, "sustain": 0.5},
+        "shrink": {"mode": "smart", "pre": 2.0, "post": 3.0, "aspect": "horizontal", "zoom": 1.0, "bias_blue": False},
+        "clips": {"min_duration": 2.0, "workers": 1},
+        "rank": {"k": 3, "max_len": 12.0, "min_tail": 4.0},
+        "reels": {"profile": "broadcast", "topk_title": "Sample Top Plays"},
+    }
+    config_path.write_text(json.dumps(config))
+
+    main(["--config", str(config_path), "detect"])
+    highlights_csv = output_dir / "highlights.csv"
+    assert highlights_csv.exists()
+
+    main(["--config", str(config_path), "shrink", "--csv", str(highlights_csv), "--out", str(output_dir / "highlights_smart.csv")])
+    refined_csv = output_dir / "highlights_smart.csv"
+    assert refined_csv.exists()
+
+    main(["--config", str(config_path), "clips", "--csv", str(refined_csv), "--outdir", str(output_dir / "clips"), "--workers", "1"])
+    clip_dir = output_dir / "clips"
+    clips = list(clip_dir.glob("clip_*.mp4"))
+    assert clips, "expected at least one clip"
+
+    main([
+        "--config",
+        str(config_path),
+        "topk",
+        "--candirs",
+        str(clip_dir),
+        "--csv",
+        str(output_dir / "smart_topk.csv"),
+        "--list",
+        str(output_dir / "smart_topk_concat.txt"),
+        "--k",
+        "2",
+    ])
+    concat_list = output_dir / "smart_topk_concat.txt"
+    assert concat_list.exists()
+
+    reel_out = output_dir / "reels" / "top10.mp4"
+    main([
+        "--config",
+        str(config_path),
+        "reel",
+        "--list",
+        str(concat_list),
+        "--out",
+        str(reel_out),
+        "--title",
+        "Test Reel",
+    ])
+    assert reel_out.exists() and reel_out.stat().st_size > 0
+
+    report_json = output_dir / "report.json"
+    assert report_json.exists()


### PR DESCRIPTION
## Summary
- introduce a `soccer_highlights` package that exposes configuration models, modular pipeline stages, and a Windows-friendly CLI
- implement FFmpeg-based clip export, top-k ranking, reel rendering, color calibration helpers, and reusable utilities
- document the new workflow, ship a default `config.yaml`, and add examples plus a regression test that exercises the end-to-end flow on a synthetic sample

## Testing
- pytest -k pipeline

------
https://chatgpt.com/codex/tasks/task_e_68c99bf98720832dad6938fbc2bcdfc9