### PR TITLE
Document motion filter tuning and update navy defaults

### DIFF
--- a/05_filter_by_motion.py
+++ b/05_filter_by_motion.py
@@ -7,7 +7,7 @@ try:
 except Exception:
     librosa = None
 
-def hsv_mask_team(frame_bgr, low=(105, 80, 20), high=(130, 255, 160)):
+def hsv_mask_team(frame_bgr, low=(105, 70, 20), high=(130, 255, 160)):
     """Return binary mask for NAVY kit in HSV (OpenCV: H 0..180)."""
     hsv = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2HSV)
     low  = np.array(low, dtype=np.uint8)
@@ -15,7 +15,7 @@ def hsv_mask_team(frame_bgr, low=(105, 80, 20), high=(130, 255, 160)):
     m = cv2.inRange(hsv, low, high)
     return m
 
-TEAM_LOW = (105, 80, 20)
+TEAM_LOW = (105, 70, 20)
 TEAM_HIGH = (130, 255, 160)
 
 def read_candidates(csv_path):
@@ -178,9 +178,16 @@ def main():
     ap.add_argument("--min-contig-frames", type=int, default=10)
     ap.add_argument("--min-center-ratio",  type=float, default=0.35)
     ap.add_argument("--min-ball-speed",    type=float, default=0.9, help="median px/frame (sampled) for ball proxy")
-    ap.add_argument("--min-flow-mean",     type=float, default=0.55, help="relative scalar on window mean flow")
+    ap.add_argument(
+        "--min-flow-mean",
+        "--min-flow",
+        dest="min_flow_mean",
+        type=float,
+        default=0.55,
+        help="relative scalar on window mean flow (alias --min-flow)",
+    )
     ap.add_argument("--audio-boost",       type=int,   default=1,    help="use spectral flux as tiebreaker")
-    ap.add_argument("--team-hsv-low",  type=str, default="105,80,20")
+    ap.add_argument("--team-hsv-low",  type=str, default="105,70,20")
     ap.add_argument("--team-hsv-high", type=str, default="130,255,160")
     ap.add_argument("--min-team-pres", type=float, default=0.12, help="min fraction of motion that is team color (navy)")
     ap.add_argument("--team-bias",     type=float, default=0.25, help="score bonus weight for team presence")

--- a/README.md
+++ b/README.md
@@ -55,6 +55,26 @@ to regenerate clips when needed.
 Each command updates `out/report.md` with summary statistics so you always know
 how many windows, clips, and reel duration were produced.
 
+## Motion Filter Tuning Notes
+
+The optional `05_filter_by_motion.py` stage keeps the most action-packed windows
+by combining motion strength, a rough ball-speed proxy, and a navy jersey mask.
+You can adjust several parameters when your footage or uniforms differ from the
+defaults:
+
+* **Jersey mask** – `--team-hsv-low`/`--team-hsv-high` accept `H,S,V` triplets in
+  OpenCV ranges. The dark-navy defaults are `105,70,20` through `130,255,160`.
+  Raise the upper V toward `190` when clips look too dim, or increase the lower
+  S to ~`90` if the mask is catching sky and bleachers.
+* **Sensitivity knobs** – Lower `--min-flow-mean` (alias `--min-flow`) when fast
+  plays are being dropped, or reduce `--min-ball-speed` when the ball appears
+  small or far from the camera. Raising `--min-center-ratio` nudges the filter
+  toward activity in the attacking thirds.
+
+The filter now drops windows with low residual motion (such as pure camera pans)
+and those lacking a moving ball or visible pitch, so expect filler "in-between"
+clips to disappear as thresholds tighten.
+
 ## Examples & Tests
 
 `examples/generate_sample.py` creates a small synthetic match clip that drives a


### PR DESCRIPTION
## Summary
- document the key tuning levers for the motion filter stage in the README
- add a `--min-flow` alias and adjust the default navy HSV triplet to match the docs

## Testing
- pytest -k pipeline


------
https://chatgpt.com/codex/tasks/task_e_68ca9f3fc6cc832d8050f271befb7102