### PR TITLE
Add cheer-anchored top10 builder and tests

### DIFF
--- a/08b_build_top10_cheers.py
+++ b/08b_build_top10_cheers.py
@@ -1,0 +1,84 @@
+import argparse
+from pathlib import Path
+
+from soccer_highlights.top10_cheers import build_cheers_top10
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Build Top-10 clips using cheers as optional anchors",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--video", default="out/full_game_stabilized.mp4", help="Input match video")
+    parser.add_argument(
+        "--filtered",
+        default="out/highlights_filtered.csv",
+        help="CSV of filtered highlight windows with action_score",
+    )
+    parser.add_argument("--cheers", help="CSV of cheer timestamps to force include", default=None)
+    parser.add_argument("--clips-dir", default="out/clips_top10", help="Directory for exported clips")
+    parser.add_argument("--concat", default="out/concat_top10.txt", help="Concat file for ffmpeg")
+    parser.add_argument("--out", default="out/top10.mp4", help="Concatenated Top-10 video output")
+    parser.add_argument("--csv-out", help="Optional CSV summary of selected windows")
+    parser.add_argument("--n", type=int, default=10, help="Maximum number of clips to keep")
+    parser.add_argument("--pre", type=float, default=2.0, help="Seconds to pad before each window")
+    parser.add_argument("--post", type=float, default=3.0, help="Seconds to pad after each window")
+    parser.add_argument("--min-len", type=float, default=0.8, help="Minimum clip duration after padding")
+    parser.add_argument(
+        "--overlap",
+        type=float,
+        default=0.5,
+        help="Drop clips that overlap an accepted one by more than this fraction",
+    )
+    parser.add_argument("--cheer-max", type=int, default=4, help="Maximum number of cheer anchors")
+    parser.add_argument("--cheer-gap", type=float, default=45.0, help="Minimum spacing between cheers in seconds")
+    parser.add_argument("--cheer-pre", type=float, default=7.5, help="Seconds of context before cheer peak")
+    parser.add_argument("--cheer-post", type=float, default=2.5, help="Seconds after cheer peak")
+    parser.add_argument("--cheer-min-len", type=float, default=0.8, help="Minimum cheer clip length before padding")
+    parser.add_argument("--ffmpeg", default="ffmpeg", help="Path to ffmpeg executable")
+    parser.add_argument("--ffprobe", default="ffprobe", help="Path to ffprobe executable")
+    parser.add_argument(
+        "--fallback-duration",
+        type=float,
+        help="Use this duration if ffprobe cannot determine it",
+    )
+    parser.add_argument(
+        "--skip-render",
+        action="store_true",
+        help="Compute selections but skip ffmpeg rendering (useful for tests)",
+    )
+    args = parser.parse_args()
+
+    selected = build_cheers_top10(
+        video_path=Path(args.video),
+        filtered_csv=Path(args.filtered),
+        cheers_csv=Path(args.cheers) if args.cheers else None,
+        clips_dir=Path(args.clips_dir),
+        concat_path=Path(args.concat),
+        output_video=Path(args.out),
+        max_count=args.n,
+        pad_pre=args.pre,
+        pad_post=args.post,
+        min_length=args.min_len,
+        overlap_threshold=args.overlap,
+        cheer_max=args.cheer_max,
+        cheer_spacing=args.cheer_gap,
+        cheer_pre=args.cheer_pre,
+        cheer_post=args.cheer_post,
+        cheer_min_length=args.cheer_min_len,
+        ffmpeg=args.ffmpeg,
+        ffprobe=args.ffprobe,
+        fallback_duration=args.fallback_duration,
+        csv_out=Path(args.csv_out) if args.csv_out else None,
+        skip_render=args.skip_render,
+    )
+
+    if args.skip_render:
+        print(f"Selected {len(selected)} clips (render skipped)")
+    else:
+        print(f"DONE: {args.out}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ to regenerate clips when needed.
 Each command updates `out/report.md` with summary statistics so you always know
 how many windows, clips, and reel duration were produced.
 
+### Cheer-anchored Top-10
+
+When you have a CSV of cheer timestamps (see `09_detect_cheers.py`), run
+`08b_build_top10_cheers.py` to guarantee those big moments appear in the final
+Top-10 reel. The script keeps up to four well-spaced cheers, pads each window
+with additional context, fills remaining slots using the highest
+`action_score` clips from `out/highlights_filtered.csv`, then renders
+`out/top10.mp4` along with the individual clips and concat list.
+
 ## Examples & Tests
 
 `examples/generate_sample.py` creates a small synthetic match clip that drives a

--- a/soccer_highlights/top10_cheers.py
+++ b/soccer_highlights/top10_cheers.py
@@ -1,0 +1,460 @@
+"""Utilities for building Top-10 reels anchored by crowd cheers."""
+from __future__ import annotations
+
+import csv
+import math
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+
+@dataclass
+class ClipCandidate:
+    """A highlight window candidate before padding/overlap resolution."""
+
+    start: float
+    end: float
+    score: float
+    priority: int
+    source: str
+
+
+@dataclass
+class SelectedClip:
+    """A highlight window selected for export with padding applied."""
+
+    start: float
+    end: float
+    score: float
+    source: str
+    raw_start: float
+    raw_end: float
+
+
+_NUMERIC_RE = re.compile(r"[^0-9.\-]+")
+
+
+def _parse_float(value: object) -> float | None:
+    """Parse a float from loosely formatted CSV values.
+
+    Values may contain stray characters such as "s" or "sec". The PowerShell
+    prototype that inspired this module stripped everything except digits,
+    decimal points and minus signs, so we do the same for compatibility.
+    """
+
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    text = str(value).strip()
+    if not text:
+        return None
+    cleaned = _NUMERIC_RE.sub("", text)
+    if not cleaned:
+        return None
+    try:
+        return float(cleaned)
+    except ValueError:
+        return None
+
+
+def load_cheer_candidates(
+    csv_path: Path,
+    duration: float,
+    max_count: int = 4,
+    min_spacing: float = 45.0,
+    pre_window: float = 7.5,
+    post_window: float = 2.5,
+    min_length: float = 0.8,
+) -> List[ClipCandidate]:
+    """Load forced highlight windows anchored on cheer timestamps."""
+
+    if not csv_path.exists():
+        return []
+
+    with csv_path.open("r", newline="", encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        if reader.fieldnames is None:
+            return []
+        # look for a column named "time" (case insensitive). Fallback to first column.
+        columns = [name.lower() for name in reader.fieldnames]
+        try:
+            time_idx = columns.index("time")
+            time_key = reader.fieldnames[time_idx]
+        except ValueError:
+            time_key = reader.fieldnames[0]
+
+        cheer_times: List[float] = []
+        for row in reader:
+            t = _parse_float(row.get(time_key))
+            if t is None:
+                continue
+            cheer_times.append(t)
+
+    cheer_times.sort()
+    picked: List[float] = []
+    for ts in cheer_times:
+        if len(picked) >= max_count:
+            break
+        if not picked or abs(ts - picked[-1]) >= min_spacing:
+            picked.append(ts)
+
+    forced: List[ClipCandidate] = []
+    for ts in picked:
+        start = max(0.0, ts - pre_window)
+        end = min(duration, ts + post_window)
+        if end - start < min_length:
+            continue
+        forced.append(
+            ClipCandidate(
+                start=start,
+                end=end,
+                score=999.0,
+                priority=0,
+                source="cheer",
+            )
+        )
+    return forced
+
+
+def load_filtered_candidates(csv_path: Path) -> List[ClipCandidate]:
+    """Load ranked highlight windows from the motion/action filter."""
+
+    if not csv_path.exists():
+        return []
+
+    with csv_path.open("r", newline="", encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        if reader.fieldnames is None:
+            return []
+
+        candidates: List[ClipCandidate] = []
+        for row in reader:
+            start = _parse_float(row.get("start"))
+            end = _parse_float(row.get("end"))
+            if start is None or end is None:
+                continue
+            if end <= start:
+                continue
+            score_value = None
+            for key in ("action_score", "score"):
+                score_value = _parse_float(row.get(key))
+                if score_value is not None:
+                    break
+            if score_value is None:
+                score_value = 0.0
+            candidates.append(
+                ClipCandidate(
+                    start=start,
+                    end=end,
+                    score=score_value,
+                    priority=1,
+                    source="filtered",
+                )
+            )
+    return candidates
+
+
+def rank_candidates(candidates: Iterable[ClipCandidate]) -> List[ClipCandidate]:
+    """Sort candidates by priority and score (descending)."""
+
+    return sorted(candidates, key=lambda c: (c.priority, -c.score))
+
+
+def select_top_candidates(
+    candidates: Sequence[ClipCandidate],
+    duration: float,
+    max_count: int,
+    pad_pre: float,
+    pad_post: float,
+    min_length: float,
+    overlap_threshold: float,
+) -> List[SelectedClip]:
+    """Apply padding and overlap suppression to choose the final highlight list."""
+
+    selected: List[SelectedClip] = []
+    taken: List[tuple[float, float]] = []
+    for candidate in candidates:
+        if len(selected) >= max_count:
+            break
+
+        padded_start = max(0.0, candidate.start - pad_pre)
+        padded_end = min(duration, candidate.end + pad_post)
+        if padded_end - padded_start < min_length:
+            continue
+
+        overlap = False
+        for other_start, other_end in taken:
+            intersect = max(0.0, min(padded_end, other_end) - max(padded_start, other_start))
+            denom = max(padded_end - padded_start, other_end - other_start)
+            if denom > 0 and intersect / denom > overlap_threshold:
+                overlap = True
+                break
+        if overlap:
+            continue
+
+        selected.append(
+            SelectedClip(
+                start=padded_start,
+                end=padded_end,
+                score=candidate.score,
+                source=candidate.source,
+                raw_start=candidate.start,
+                raw_end=candidate.end,
+            )
+        )
+        taken.append((padded_start, padded_end))
+
+    return selected
+
+
+def write_selection_csv(path: Path, clips: Sequence[SelectedClip]) -> None:
+    """Write the final highlight windows to a CSV for inspection."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["start", "end", "score", "source", "raw_start", "raw_end"])
+        for clip in clips:
+            writer.writerow(
+                [
+                    f"{clip.start:.3f}",
+                    f"{clip.end:.3f}",
+                    f"{clip.score:.3f}",
+                    clip.source,
+                    f"{clip.raw_start:.3f}",
+                    f"{clip.raw_end:.3f}",
+                ]
+            )
+
+
+def _run_command(cmd: Sequence[str]) -> None:
+    result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(
+            "Command failed with code %s: %s\nSTDOUT: %s\nSTDERR: %s"
+            % (result.returncode, " ".join(cmd), result.stdout.strip(), result.stderr.strip())
+        )
+
+
+def probe_duration(video_path: Path, ffprobe: str = "ffprobe", fallback: float | None = None) -> float:
+    """Return the video duration in seconds using ffprobe."""
+
+    cmd = [
+        ffprobe,
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "default=nw=1:nk=1",
+        str(video_path),
+    ]
+    try:
+        result = subprocess.run(cmd, check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    except FileNotFoundError as exc:
+        if fallback is not None:
+            return fallback
+        raise RuntimeError("ffprobe not found; install FFmpeg or supply fallback duration") from exc
+
+    if result.returncode == 0:
+        output = result.stdout.strip()
+        try:
+            value = float(output)
+            if math.isfinite(value):
+                return value
+        except ValueError:
+            pass
+
+    if fallback is not None:
+        return fallback
+
+    raise RuntimeError(
+        f"Unable to determine duration for {video_path}. ffprobe output: {result.stderr.strip() or result.stdout.strip()}"
+    )
+
+
+def render_clips(
+    video_path: Path,
+    clips: Sequence[SelectedClip],
+    output_dir: Path,
+    ffmpeg: str = "ffmpeg",
+    video_codec: str = "libx264",
+    preset: str = "veryfast",
+    crf: int = 20,
+    audio_bitrate: str = "160k",
+) -> List[Path]:
+    """Render individual highlight clips using ffmpeg."""
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    # Remove old clips but keep directory.
+    for old_file in output_dir.glob("*"):
+        if old_file.is_file():
+            old_file.unlink()
+
+    exported: List[Path] = []
+    for idx, clip in enumerate(clips, start=1):
+        start_ts = f"{clip.start:.2f}"
+        end_ts = f"{clip.end:.2f}"
+        out_path = output_dir / f"clip_{idx:04d}.mp4"
+        cmd = [
+            ffmpeg,
+            "-hide_banner",
+            "-loglevel",
+            "warning",
+            "-y",
+            "-i",
+            str(video_path),
+            "-ss",
+            start_ts,
+            "-to",
+            end_ts,
+            "-c:v",
+            video_codec,
+            "-preset",
+            preset,
+            "-crf",
+            str(crf),
+            "-c:a",
+            "aac",
+            "-b:a",
+            audio_bitrate,
+            str(out_path),
+        ]
+        _run_command(cmd)
+        if out_path.exists() and out_path.stat().st_size > 0:
+            exported.append(out_path)
+    return exported
+
+
+def write_concat_file(clips: Sequence[Path], concat_path: Path) -> None:
+    """Write a concat list file for ffmpeg."""
+
+    concat_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = []
+    for clip in sorted(clips):
+        full = clip.resolve()
+        # Use forward slashes for ffmpeg compatibility and escape single quotes.
+        normalized = full.as_posix().replace("'", "\\'")
+        lines.append(f"file '{normalized}'")
+    concat_path.write_text("\n".join(lines), encoding="ascii")
+
+
+def concat_clips(concat_path: Path, output_path: Path, ffmpeg: str = "ffmpeg") -> None:
+    """Concatenate clips using ffmpeg's concat demuxer."""
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        ffmpeg,
+        "-hide_banner",
+        "-loglevel",
+        "warning",
+        "-y",
+        "-f",
+        "concat",
+        "-safe",
+        "0",
+        "-i",
+        str(concat_path),
+        "-c",
+        "copy",
+        str(output_path),
+    ]
+    _run_command(cmd)
+
+
+def build_cheers_top10(
+    video_path: Path,
+    filtered_csv: Path,
+    cheers_csv: Path | None,
+    clips_dir: Path,
+    concat_path: Path,
+    output_video: Path,
+    *,
+    max_count: int = 10,
+    pad_pre: float = 2.0,
+    pad_post: float = 3.0,
+    min_length: float = 0.8,
+    overlap_threshold: float = 0.5,
+    cheer_max: int = 4,
+    cheer_spacing: float = 45.0,
+    cheer_pre: float = 7.5,
+    cheer_post: float = 2.5,
+    cheer_min_length: float = 0.8,
+    ffmpeg: str = "ffmpeg",
+    ffprobe: str = "ffprobe",
+    fallback_duration: float | None = None,
+    csv_out: Path | None = None,
+    skip_render: bool = False,
+) -> List[SelectedClip]:
+    """Orchestrate the full Top-10 build with optional cheer anchors."""
+
+    if not video_path.exists():
+        raise FileNotFoundError(f"Video not found: {video_path}")
+
+    duration = probe_duration(video_path, ffprobe=ffprobe, fallback=fallback_duration)
+
+    candidates: List[ClipCandidate] = []
+    if cheers_csv:
+        candidates.extend(
+            load_cheer_candidates(
+                cheers_csv,
+                duration,
+                max_count=cheer_max,
+                min_spacing=cheer_spacing,
+                pre_window=cheer_pre,
+                post_window=cheer_post,
+                min_length=cheer_min_length,
+            )
+        )
+    candidates.extend(load_filtered_candidates(filtered_csv))
+
+    ranked = rank_candidates(candidates)
+    if not ranked:
+        raise RuntimeError("No highlight candidates found; check CSV inputs")
+
+    selected = select_top_candidates(
+        ranked,
+        duration=duration,
+        max_count=max_count,
+        pad_pre=pad_pre,
+        pad_post=pad_post,
+        min_length=min_length,
+        overlap_threshold=overlap_threshold,
+    )
+
+    if csv_out is not None:
+        write_selection_csv(csv_out, selected)
+
+    if skip_render or not selected:
+        return selected
+
+    clip_paths = render_clips(video_path, selected, clips_dir, ffmpeg=ffmpeg)
+    # Filter out zero-sized clips as an extra guard before writing concat.
+    clip_paths = [path for path in clip_paths if path.exists() and path.stat().st_size > 0]
+    if not clip_paths:
+        raise RuntimeError("No clips were rendered; ensure ffmpeg is available")
+
+    write_concat_file(clip_paths, concat_path)
+    concat_clips(concat_path, output_video, ffmpeg=ffmpeg)
+
+    return selected
+
+
+__all__ = [
+    "ClipCandidate",
+    "SelectedClip",
+    "load_cheer_candidates",
+    "load_filtered_candidates",
+    "rank_candidates",
+    "select_top_candidates",
+    "write_selection_csv",
+    "render_clips",
+    "write_concat_file",
+    "concat_clips",
+    "probe_duration",
+    "build_cheers_top10",
+]
+

--- a/tests/test_top10_cheers.py
+++ b/tests/test_top10_cheers.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import csv
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "soccer_highlights" / "top10_cheers.py"
+SPEC = importlib.util.spec_from_file_location("top10_cheers", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:  # pragma: no cover - sanity guard
+    raise RuntimeError("Unable to load top10_cheers module")
+TOP10 = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = TOP10
+SPEC.loader.exec_module(TOP10)
+
+build_cheers_top10 = TOP10.build_cheers_top10
+load_cheer_candidates = TOP10.load_cheer_candidates
+load_filtered_candidates = TOP10.load_filtered_candidates
+rank_candidates = TOP10.rank_candidates
+select_top_candidates = TOP10.select_top_candidates
+
+
+def write_csv(path: Path, header: list[str], rows: list[list[object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(header)
+        for row in rows:
+            writer.writerow(row)
+
+
+def test_load_cheer_candidates_spacing(tmp_path: Path) -> None:
+    cheers_csv = tmp_path / "cheers.csv"
+    write_csv(
+        cheers_csv,
+        ["time"],
+        [
+            [5],
+            [40],
+            [90],
+            [150],
+            [220],
+            [280],
+        ],
+    )
+
+    forced = load_cheer_candidates(cheers_csv, duration=300.0, max_count=4, min_spacing=45.0)
+    assert len(forced) == 4
+    # First cheer starts before zero and should clamp to 0 after applying pre window
+    assert forced[0].start == 0.0
+    # Spacing ensures later cheers are kept even if there are extras
+    assert forced[-1].start < 300.0
+
+
+def test_select_top_candidates_prioritises_cheers(tmp_path: Path) -> None:
+    filtered_csv = tmp_path / "filtered.csv"
+    write_csv(
+        filtered_csv,
+        ["start", "end", "action_score"],
+        [
+            [100, 105, 5.0],
+            [160, 166, 3.0],
+            [200, 205, 4.2],
+        ],
+    )
+
+    cheers_csv = tmp_path / "cheers.csv"
+    write_csv(cheers_csv, ["time"], [[110], [170], [250]])
+
+    forced = load_cheer_candidates(cheers_csv, duration=400.0)
+    filtered = load_filtered_candidates(filtered_csv)
+    ranked = rank_candidates(forced + filtered)
+    selected = select_top_candidates(
+        ranked,
+        duration=400.0,
+        max_count=5,
+        pad_pre=2.0,
+        pad_post=3.0,
+        min_length=0.8,
+        overlap_threshold=0.5,
+    )
+
+    assert selected, "expected cheer anchors to yield selections"
+    cheer_sources = [clip for clip in selected if clip.source == "cheer"]
+    assert len(cheer_sources) >= 1
+    # ensure selections maintain chronological padding and no duplicates beyond limit
+    assert all(clip.end > clip.start for clip in selected)
+
+
+@pytest.mark.parametrize("cheer_gap", [45.0, 30.0])
+def test_build_cheers_top10_skip_render(tmp_path: Path, cheer_gap: float) -> None:
+    video_path = tmp_path / "fake_video.mp4"
+    video_path.write_bytes(b"fake")
+
+    filtered_csv = tmp_path / "filtered.csv"
+    write_csv(
+        filtered_csv,
+        ["start", "end", "action_score"],
+        [
+            [50, 55, 1.0],
+            [90, 95, 2.0],
+            [140, 146, 3.0],
+        ],
+    )
+
+    cheers_csv = tmp_path / "cheers.csv"
+    write_csv(cheers_csv, ["time"], [[60], [120], [180]])
+
+    csv_out = tmp_path / "selected.csv"
+    clips_dir = tmp_path / "clips"
+    concat_path = tmp_path / "concat.txt"
+    out_video = tmp_path / "top10.mp4"
+
+    selected = build_cheers_top10(
+        video_path=video_path,
+        filtered_csv=filtered_csv,
+        cheers_csv=cheers_csv,
+        clips_dir=clips_dir,
+        concat_path=concat_path,
+        output_video=out_video,
+        max_count=3,
+        pad_pre=1.0,
+        pad_post=1.0,
+        min_length=0.5,
+        overlap_threshold=0.5,
+        cheer_max=2,
+        cheer_spacing=cheer_gap,
+        cheer_pre=5.0,
+        cheer_post=2.0,
+        cheer_min_length=0.5,
+        ffmpeg="ffmpeg",  # won't be invoked due to skip_render
+        ffprobe=str(tmp_path / "missing_ffprobe"),
+        fallback_duration=400.0,
+        csv_out=csv_out,
+        skip_render=True,
+    )
+
+    assert selected, "expected at least one selected clip"
+    assert csv_out.exists()
+    assert not clips_dir.exists(), "skip_render should not create clips"
+


### PR DESCRIPTION
## Summary
- add a reusable builder in `soccer_highlights.top10_cheers` that injects cheer anchors, pads windows, renders clips, and writes concat lists
- expose the workflow via a new helper script `08b_build_top10_cheers.py`
- document the cheer anchored workflow and add unit tests for the selection logic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ca9f17c33c832da361725b2eec98ce