### PR TITLE
Add clip blocking state and cooldown utilities

### DIFF
--- a/soccer_highlights/__init__.py
+++ b/soccer_highlights/__init__.py
@@ -1,5 +1,6 @@
 """Soccer highlights extraction toolkit."""
 
+from .blocking import ClipBlockState, first_live_frame
 from .config import AppConfig, load_config
 
-__all__ = ["AppConfig", "load_config"]
+__all__ = ["AppConfig", "ClipBlockState", "first_live_frame", "load_config"]

--- a/soccer_highlights/blocking.py
+++ b/soccer_highlights/blocking.py
@@ -1,0 +1,204 @@
+"""Helpers for suppressing highlight clips around stoppages and restarts.
+
+The detection scripts emit coarse event tags such as restarts, ball-out,
+and prolonged stoppages.  To avoid producing highlight clips from those
+moments we maintain a :class:`ClipBlockState` that tracks two concepts:
+
+``block_until``
+    Absolute time before which new clips should be discarded.  This is
+    primarily driven by restart tags – we wait until the first live touch
+    after the restart before considering new highlights.
+
+``no_clip_windows``
+    A merged list of intervals that should not produce clips.  These grow
+    as we observe the ball exiting play or a stoppage cluster (medical
+    staff, substitutions, referee conference, ...).  The windows "slide"
+    forward as new tags arrive, ensuring we never output footage of the
+    dead-ball sequences themselves.
+
+The functions below remain agnostic of the underlying video analytics –
+tests provide synthetic touch timestamps to validate the behaviour.  Real
+detectors simply need to supply the times at which a first touch (or other
+"live" signal) was observed after a given anchor.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Iterable, List, Sequence, Tuple
+
+__all__ = ["ClipBlockState", "first_live_frame"]
+
+if TYPE_CHECKING:  # pragma: no cover - typing aid
+    from .utils import HighlightWindow
+
+
+def _merge_intervals(intervals: List[Tuple[float, float]], *, epsilon: float = 1e-6) -> List[Tuple[float, float]]:
+    """Merge overlapping or touching intervals.
+
+    ``epsilon`` avoids tiny floating point gaps from splitting otherwise
+    continuous regions.
+    """
+
+    if not intervals:
+        return []
+    ordered = sorted((max(0.0, start), max(0.0, end)) for start, end in intervals if end > start)
+    if not ordered:
+        return []
+    merged: List[Tuple[float, float]] = [ordered[0]]
+    for start, end in ordered[1:]:
+        last_start, last_end = merged[-1]
+        if start <= last_end + epsilon:
+            merged[-1] = (last_start, max(last_end, end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def first_live_frame(
+    anchor_time: float,
+    touch_times: Sequence[float] | None,
+    *,
+    max_wait: float = 8.0,
+    fallback: float | None = None,
+) -> float:
+    """Return the first time at or after ``anchor_time`` where play resumes.
+
+    ``touch_times`` should contain timestamps (in seconds) where the ball
+    was touched or otherwise deemed "live".  The function returns the first
+    such timestamp greater than or equal to ``anchor_time``.  When no touch
+    is observed within ``max_wait`` seconds we fall back to either the
+    supplied ``fallback`` value or ``anchor_time + max_wait``.
+    """
+
+    limit = anchor_time + max_wait
+    tolerance = 1e-3
+    if touch_times:
+        for ts in sorted(touch_times):
+            if ts + tolerance >= anchor_time:
+                return min(max(ts, anchor_time), limit)
+    if fallback is not None:
+        return min(max(fallback, anchor_time), limit)
+    return limit
+
+
+@dataclass
+class ClipBlockState:
+    """Track clip suppression windows derived from event tags."""
+
+    block_until: float = 0.0
+    _no_clip: List[Tuple[float, float]] = field(default_factory=list)
+
+    @property
+    def no_clip_windows(self) -> List[Tuple[float, float]]:
+        """Return merged no-clip windows accumulated so far."""
+
+        return list(self._no_clip)
+
+    def _add_zone(self, start: float, end: float) -> Tuple[float, float]:
+        if end <= start:
+            return start, start
+        self._no_clip.append((start, end))
+        self._no_clip = _merge_intervals(self._no_clip)
+        return start, end
+
+    def record_restart(
+        self,
+        restart_time: float,
+        touches: Sequence[float] | None,
+        *,
+        cooldown: float = 3.0,
+        max_wait: float = 8.0,
+    ) -> float:
+        """Register a restart and extend ``block_until`` until play resumes."""
+
+        resume = first_live_frame(
+            restart_time,
+            touches,
+            max_wait=max_wait,
+            fallback=restart_time + cooldown,
+        )
+        self.block_until = max(self.block_until, resume)
+        self._add_zone(restart_time, resume)
+        return resume
+
+    def add_out_of_play(
+        self,
+        exit_time: float,
+        *,
+        return_time: float | None = None,
+        touches: Sequence[float] | None = None,
+        linger: float = 0.5,
+        max_wait: float = 8.0,
+    ) -> Tuple[float, float]:
+        """Suppress clips while the ball is out of play.
+
+        ``return_time`` can be supplied when the detector explicitly
+        observes the re-entry frame; otherwise we fall back to the next
+        touch timestamp (or ``exit_time + max_wait``).
+        """
+
+        anchor = return_time if return_time is not None else exit_time
+        resume = first_live_frame(
+            anchor,
+            touches,
+            max_wait=max_wait,
+            fallback=anchor + max_wait,
+        )
+        resume = max(resume + linger, exit_time)
+        return self._add_zone(exit_time, resume)
+
+    def add_stoppage(
+        self,
+        start: float,
+        end: float,
+        *,
+        touches: Sequence[float] | None = None,
+        linger: float = 1.0,
+        max_wait: float = 8.0,
+    ) -> Tuple[float, float]:
+        """Add a no-clip window for a stoppage cluster."""
+
+        resume = first_live_frame(
+            end,
+            touches,
+            max_wait=max_wait,
+            fallback=end + linger,
+        )
+        resume = max(resume, end + linger)
+        return self._add_zone(start, resume)
+
+    def is_blocked(self, start: float, end: float) -> bool:
+        """Return ``True`` when the given span overlaps a suppression zone."""
+
+        if end <= start:
+            return False
+        if start < self.block_until:
+            return True
+        for zone_start, zone_end in self._no_clip:
+            if start < zone_end and end > zone_start:
+                return True
+        return False
+
+    def filter_windows(
+        self,
+        windows: Sequence["HighlightWindow"],
+        *,
+        banned_events: Iterable[str] | None = None,
+    ) -> List["HighlightWindow"]:
+        """Drop windows that fall inside suppression regions or categories."""
+
+        if banned_events is None:
+            banned = {"restart", "setup"}
+        else:
+            banned = set(banned_events)
+
+        kept: List["HighlightWindow"] = []
+        for win in windows:
+            if win.event in banned:
+                continue
+            if self.is_blocked(win.start, win.end):
+                continue
+            kept.append(win)
+        return kept
+

--- a/soccer_highlights/config.py
+++ b/soccer_highlights/config.py
@@ -24,6 +24,10 @@ class DetectConfig(BaseModel):
     hysteresis: float = Field(0.3, description="Fraction of threshold used as low hysteresis.")
     sustain: float = Field(1.0, description="Seconds a detection must sustain to be accepted.")
     merge_hysteresis: float = Field(0.75, description="Merge overlapping windows when overlap exceeds this fraction.")
+    exclude_events: list[str] = Field(
+        default_factory=lambda: ["restart", "setup"],
+        description="Event categories that should be dropped before merging windows.",
+    )
 
 
 class ShrinkConfig(BaseModel):

--- a/soccer_highlights/detect.py
+++ b/soccer_highlights/detect.py
@@ -156,6 +156,10 @@ def detect_highlights(config: AppConfig, video_path: Path, output_csv: Path) -> 
         else:
             idx += 1
 
+    banned = {event.lower() for event in (config.detect.exclude_events or [])}
+    if banned:
+        windows = [w for w in windows if str(w.event).lower() not in banned]
+
     merged = merge_overlaps(windows, config.detect.min_gap)
     merged.sort(key=lambda w: w.score, reverse=True)
     if config.detect.max_count:

--- a/tests/test_blocking.py
+++ b/tests/test_blocking.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load module at {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BLOCKING = _load_module(ROOT / "soccer_highlights" / "blocking.py", "blocking_mod")
+ClipBlockState = BLOCKING.ClipBlockState
+first_live_frame = BLOCKING.first_live_frame
+
+
+@dataclass
+class HighlightWindow:
+    start: float
+    end: float
+    score: float
+    event: str = "scene"
+
+
+def test_first_live_frame_uses_next_touch() -> None:
+    touches = [12.0, 18.5, 24.0]
+    assert first_live_frame(17.0, touches) == pytest.approx(18.5)
+
+
+def test_first_live_frame_fallback_when_missing() -> None:
+    assert first_live_frame(5.0, [], fallback=8.2, max_wait=10.0) == pytest.approx(8.2)
+
+
+def test_clip_block_state_blocks_until_touch() -> None:
+    state = ClipBlockState()
+    resume = state.record_restart(30.0, touches=[31.0, 33.5])
+    assert resume == pytest.approx(31.0)
+    assert state.block_until == pytest.approx(31.0)
+    assert state.is_blocked(29.0, 30.5)
+    assert not state.is_blocked(32.0, 34.0)
+
+
+def test_out_of_play_merges_overlaps() -> None:
+    state = ClipBlockState()
+    state.add_out_of_play(10.0, touches=[11.0], linger=0.0, max_wait=5.0)
+    state.add_out_of_play(10.8, touches=[12.0], linger=0.0, max_wait=5.0)
+    zones = state.no_clip_windows
+    assert len(zones) == 1
+    start, end = zones[0]
+    assert start == pytest.approx(10.0)
+    assert end == pytest.approx(12.0)
+
+
+def test_stoppage_zone_extends_beyond_cluster() -> None:
+    state = ClipBlockState()
+    zone = state.add_stoppage(40.0, 42.0, touches=[43.5], linger=1.0)
+    assert zone[0] == pytest.approx(40.0)
+    assert zone[1] == pytest.approx(43.5)
+
+
+def test_filter_windows_excludes_categories_and_zones() -> None:
+    state = ClipBlockState()
+    state.add_out_of_play(95.0, touches=[98.0], linger=0.0)
+    windows = [
+        HighlightWindow(start=90.0, end=92.0, score=0.5, event="scene"),
+        HighlightWindow(start=94.0, end=96.0, score=0.6, event="restart"),
+        HighlightWindow(start=96.5, end=97.2, score=0.4, event="scene"),
+    ]
+    filtered = state.filter_windows(windows)
+    assert len(filtered) == 1
+    assert filtered[0].start == pytest.approx(90.0)


### PR DESCRIPTION
## Summary
- add a reusable clip blocking state that tracks restart cooldowns and stoppage no-clip windows
- expose the blocking helpers via the package init and drop configurable event categories during detection
- cover the new logic with dedicated tests exercising cooldown, out-of-play, and stoppage handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb6b7bb0d4832dbee1f9811669ef03