### PR TITLE
Refine Navy highlight ranking and add reel tooling

### DIFF
--- a/config/reels.json
+++ b/config/reels.json
@@ -1,0 +1,7 @@
+{
+  "presets": {
+    "youtube_1080p": { "width": 1920, "height": 1080, "fps": 24, "afilters": "loudnorm=I=-16:TP=-1.5:LRA=11", "vf": "" },
+    "tiktok_9x16":   { "width": 1080, "height": 1920, "fps": 24, "afilters": "loudnorm=I=-16:TP=-1.5:LRA=11", "vf": "scale=1080:-2:flags=lanczos, crop=1080:1920" },
+    "square_1x1":    { "width": 1080, "height": 1080, "fps": 24, "afilters": "loudnorm=I=-16:TP=-1.5:LRA=11", "vf": "scale=1080:-2:flags=lanczos, crop=1080:1080" }
+  }
+}

--- a/config/team_navy.json
+++ b/config/team_navy.json
@@ -1,0 +1,7 @@
+{
+  "team_name": "Navy",
+  "hsv_low": [100, 25, 25],
+  "hsv_high": [140, 255, 255],
+  "presence_min": 0.55,
+  "presence_bias": 1.35
+}

--- a/scripts/render_reel.ps1
+++ b/scripts/render_reel.ps1
@@ -1,0 +1,12 @@
+param(
+  [string]$Concat = ".\out\concat_goals_plus_top.txt",
+  [string]$Preset = "tiktok_9x16",
+  [string]$OutFile = ".\out\reel.mp4",
+  [string]$PresetsJson = ".\config\reels.json"
+)
+$cfg = Get-Content $PresetsJson | ConvertFrom-Json
+$p = $cfg.presets.$Preset
+if ($null -eq $p) { throw "Unknown preset: $Preset" }
+$vf = $p.vf; if ([string]::IsNullOrEmpty($vf)) { $vf = "scale=$($p.width):-2:flags=lanczos" }
+ffmpeg -f concat -safe 0 -i $Concat -r $($p.fps) -g ($p.fps*2) -vf $vf -c:v libx264 -preset veryfast -crf 22 -pix_fmt yuv420p -c:a aac -ar 48000 -af $p.afilters -movflags +faststart -y $OutFile
+Write-Host "[rendered] $Preset -> $OutFile"

--- a/scripts/run_highlights_compat.ps1
+++ b/scripts/run_highlights_compat.ps1
@@ -1,106 +1,104 @@
-﻿param(
+param(
   [string]$Video = ".\out\full_game_stabilized.mp4",
   [string]$OutDir = ".\out",
   [switch]$Reencode
 )
 
 $ErrorActionPreference = "Stop"
-
 if (!(Test-Path $Video)) { throw "Missing input video: $Video" }
 New-Item -ItemType Directory -Force -Path $OutDir, ".\scripts" | Out-Null
 
 $env:PYTHONUNBUFFERED = "1"
-$venv = ".\.venv\Scripts\Activate.ps1"; if (Test-Path $venv) { & $venv }
+$venv = ".\.venv\Scripts\Activate.ps1"
+if (Test-Path $venv) { & $venv }
 
-$topDir   = Join-Path $OutDir "clips_top"
-$goalsDir = Join-Path $OutDir "clips_goals"
 $logsDir  = Join-Path $OutDir "logs"
-New-Item -ItemType Directory -Force -Path $topDir,$goalsDir,$logsDir | Out-Null
+New-Item -ItemType Directory -Force -Path $logsDir | Out-Null
 
 # Clean prior artifacts
-@("highlights.csv","goal_resets.csv","plays.csv",
-  "concat_goals.txt","concat_goals_plus_top.txt",
-  "top_highlights_goals.mp4","top_highlights_goals_first.mp4") |
+@( "highlights.csv", "goal_resets.csv", "plays.csv", "segments.tsv",
+   "concat_goals.txt", "concat_goals_plus_top.txt",
+   "top_highlights_goals.mp4", "top_highlights_goals_first.mp4" ) |
   ForEach-Object { Remove-Item (Join-Path $OutDir $_) -ErrorAction SilentlyContinue }
-Remove-Item "$topDir\*", "$goalsDir\*" -Recurse -ErrorAction SilentlyContinue
+Remove-Item (Join-Path $OutDir "clips_top\*"), (Join-Path $OutDir "clips_goals\*") -Recurse -ErrorAction SilentlyContinue
 
-# 1) Detect events (legacy args; bias to Navy/blue; tighter pre/post)
-$hiCSV = Join-Path $OutDir "highlights.csv"
+$hiCSV   = Join-Path $OutDir "highlights.csv"
+$grCSV   = Join-Path $OutDir "goal_resets.csv"
+$playsCSV = Join-Path $OutDir "plays.csv"
+
+# 1) Detect events
 & python -u .\02_detect_events.py `
   --video $Video `
   --out $hiCSV `
   --sample-fps 30 `
   --pass-window 2.0 `
   --passes-needed 3 `
-  --pre 1.0 --post 2.0 `
+  --pre 1.0 `
+  --post 2.0 `
   --bias-blue 2>&1 | Tee-Object (Join-Path $logsDir "02_detect_events.log")
-if ($LASTEXITCODE -ne 0) { throw "02_detect_events.py failed (see logs\02_detect_events.log)" }
+if ($LASTEXITCODE -ne 0) { throw "02_detect_events.py failed (see logs\\02_detect_events.log)" }
 
-# 2) Goal resets
-$grCSV = Join-Path $OutDir "goal_resets.csv"
-& python -u .\06_detect_goal_resets.py `
-  --video $Video `
-  --out $grCSV 2>&1 | Tee-Object (Join-Path $logsDir "06_detect_goal_resets.log")
-if ($LASTEXITCODE -ne 0) { throw "06_detect_goal_resets.py failed (see logs\06_detect_goal_resets.log)" }
+# 2) Goal resets (optional)
+try {
+  & python -u .\06_detect_goal_resets.py `
+    --video $Video `
+    --out $grCSV 2>&1 | Tee-Object (Join-Path $logsDir "06_detect_goal_resets.log")
+  if ($LASTEXITCODE -ne 0) { throw "goal reset detector failed" }
+} catch {
+  Write-Warning "06_detect_goal_resets.py failed or produced no data; continuing without goals."
+  Remove-Item $grCSV -ErrorAction SilentlyContinue
+}
 
-# 3) Motion filter with stricter gates (approx action-only)
+# 3) Rank actions with Navy bias
 & python -u .\05_filter_by_motion.py `
   --video $Video `
-  --highlights $hiCSV `
-  --goal-resets $grCSV `
-  --min-flow 2.2 `
-  --min-moving-players 4 `
-  --ball-on-pitch-required `
-  --top-dir $topDir `
-  --goals-dir $goalsDir 2>&1 | Tee-Object (Join-Path $logsDir "05_filter_by_motion.log")
-if ($LASTEXITCODE -ne 0) { throw "05_filter_by_motion.py failed (see logs\05_filter_by_motion.log)" }
+  --csv $hiCSV `
+  --out $playsCSV `
+  --min-flow-mean 2.0 `
+  --min-contig-frames 15 `
+  --min-ball-speed 2.5 `
+  --min-center-ratio 0.12 `
+  --need-ball 1 `
+  --navy-json .\config\team_navy.json `
+  --team-hsv-low 100,25,25 `
+  --team-hsv-high 140,255,255 `
+  --rank-top 30 `
+  --min-sep 4.0 `
+  --audio-boost 1.0 2>&1 | Tee-Object (Join-Path $logsDir "05_filter_by_motion.log")
+if ($LASTEXITCODE -ne 0) { throw "05_filter_by_motion.py failed (see logs\\05_filter_by_motion.log)" }
 
-# 4) Rebuild concat lists only if clips exist (ASCII to satisfy ffmpeg)
-$goalClips = Get-ChildItem $goalsDir -Filter *.mp4 -ErrorAction SilentlyContinue | Sort-Object Name
-$topClips  = Get-ChildItem $topDir   -Filter *.mp4 -ErrorAction SilentlyContinue | Sort-Object Name
+# 4) Build master reel (strict goals by default)
+& .\scripts\make_reel.ps1 -Video $Video -OutDir $OutDir -GoalMode "strict" 2>&1 |
+  Tee-Object (Join-Path $logsDir "make_reel.log")
+if ($LASTEXITCODE -ne 0) { throw "make_reel.ps1 failed (see logs\\make_reel.log)" }
 
+# For compatibility: optionally re-encode concat outputs
 $concatGoals = Join-Path $OutDir "concat_goals.txt"
 $concatBoth  = Join-Path $OutDir "concat_goals_plus_top.txt"
-
-if ($goalClips.Count -gt 0) {
-  $goalLines = $goalClips | ForEach-Object { "file '$($_.FullName)'" }
-  Set-Content -Path $concatGoals -Value $goalLines -Encoding ascii
-}
-
-if ($goalClips.Count -gt 0 -or $topClips.Count -gt 0) {
-  $bothLines = @()
-  $bothLines += ($goalClips | ForEach-Object { "file '$($_.FullName)'" })
-  $bothLines += ($topClips  | ForEach-Object { "file '$($_.FullName)'" })
-  Set-Content -Path $concatBoth -Value $bothLines -Encoding ascii
-}
+$outGoals = Join-Path $OutDir "top_highlights_goals.mp4"
+$outBoth  = Join-Path $OutDir "top_highlights_goals_first.mp4"
 
 function HasValidConcat($path) {
   Test-Path $path -and ((Get-Content $path | Where-Object { $_ -match '^file ' }).Count -gt 0)
 }
 
-# 5) Stitch with ffmpeg only when lists are valid
-$outGoals = Join-Path $OutDir "top_highlights_goals.mp4"
-$outBoth  = Join-Path $OutDir "top_highlights_goals_first.mp4"
-
-if (HasValidConcat $concatGoals) {
-  if ($Reencode) {
-    & ffmpeg -f concat -safe 0 -i $concatGoals -c:v libx264 -preset veryfast -crf 22 -c:a aac -movflags +faststart $outGoals
-  } else {
-    & ffmpeg -f concat -safe 0 -i $concatGoals -c copy $outGoals
-  }
+if (HasValidConcat $concatGoals -and $Reencode) {
+  & ffmpeg -f concat -safe 0 -i $concatGoals -r 24 -g 48 -c:v libx264 -preset veryfast -crf 22 -pix_fmt yuv420p -c:a aac -ar 48000 -movflags +faststart $outGoals
+}
+if (HasValidConcat $concatGoals -and -not $Reencode -and -not (Test-Path $outGoals)) {
+  & ffmpeg -f concat -safe 0 -i $concatGoals -c copy $outGoals
 }
 
-if (HasValidConcat $concatBoth) {
-  if ($Reencode) {
-    & ffmpeg -f concat -safe 0 -i $concatBoth -c:v libx264 -preset veryfast -crf 22 -c:a aac -movflags +faststart $outBoth
-  } else {
-    & ffmpeg -f concat -safe 0 -i $concatBoth -c copy $outBoth
-  }
+if (HasValidConcat $concatBoth -and $Reencode) {
+  & ffmpeg -f concat -safe 0 -i $concatBoth -r 24 -g 48 -c:v libx264 -preset veryfast -crf 22 -pix_fmt yuv420p -c:a aac -ar 48000 -movflags +faststart $outBoth
+}
+if (HasValidConcat $concatBoth -and -not $Reencode -and -not (Test-Path $outBoth)) {
+  & ffmpeg -f concat -safe 0 -i $concatBoth -c copy $outBoth
 }
 
 Write-Host "[done]"
 if (Test-Path $outGoals) { Write-Host ("  - " + $outGoals) }
 if (Test-Path $outBoth)  { Write-Host ("  - " + $outBoth) }
 if (-not (Test-Path $outGoals) -and -not (Test-Path $outBoth)) {
-  Write-Host "  (No clips survived the stricter filters -- check logs and adjust thresholds.)"
+  Write-Host "  (No clips survived the filters -- check logs and adjust thresholds.)"
 }


### PR DESCRIPTION
## Summary
- add Navy color configuration and social reel presets for flexible output targets
- replace the motion filter with Navy-aware scoring, deduplication, and ranked plays.csv output
- create PowerShell reel builders/renderers and refresh the compatibility runner to drive the new workflow

## Testing
- `python -m compileall 05_filter_by_motion.py`

<!--
Acceptance Checks:
- plays.csv must exist and have start,end,score,navy_presence with ≥10 rows for a full match.
- segments.tsv must list at least 90% “action” rows and ≤ MaxGoals “goal” rows.
- Final top_highlights_goals_first.mp4 duration ≤ MaxFractionOfRaw * raw duration.
- Visual audit: clips should start clean (no keyframe stutter), minimal “in-between” noise, obviously Navy-team advantage moments.
-->


------
https://chatgpt.com/codex/tasks/task_e_68cc39b3d79c832d85f684131b8cedd2