### PR TITLE
Implement Smart Soccer Highlight Selector pipeline

### DIFF
--- a/tools/ffconcat.py
+++ b/tools/ffconcat.py
@@ -1,0 +1,122 @@
+"""Helpers for building ``ffconcat`` playlists used by ``ffmpeg``."""
+from __future__ import annotations
+
+import dataclasses
+import logging
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+
+@dataclasses.dataclass
+class Clip:
+    """A single clip reference inside an ``ffconcat`` playlist."""
+
+    start: float
+    end: float
+    label: str = ""
+    score: float = 0.0
+
+    def duration(self) -> float:
+        return max(0.0, float(self.end) - float(self.start))
+
+
+def _validate_sorted_non_overlapping(clips: Sequence[Clip]) -> None:
+    """Validate that ``clips`` are sorted, non-overlapping and well formed."""
+
+    prev_end = None
+    for idx, clip in enumerate(clips):
+        if clip.end <= clip.start:
+            raise ValueError(f"Clip #{idx} has non-positive duration: {clip}")
+        if prev_end is not None and clip.start < prev_end - 1e-6:
+            raise ValueError(
+                f"Clip #{idx} at {clip.start:.3f}s overlaps previous end {prev_end:.3f}s"
+            )
+        prev_end = clip.end
+
+
+def sort_clips(clips: Iterable[Clip]) -> List[Clip]:
+    """Return clips sorted by their ``start`` timestamp."""
+
+    return sorted((Clip(float(c.start), float(c.end), c.label, c.score) for c in clips), key=lambda c: c.start)
+
+
+def write_ffconcat(clips: Sequence[Clip], video_path: Path, output_path: Path) -> None:
+    """Write an ``ffconcat`` file describing ``clips``.
+
+    Parameters
+    ----------
+    clips:
+        Ordered clips to be written. They must already be validated as
+        chronologically sorted and non-overlapping.
+    video_path:
+        Path to the source video. The file is referenced with an absolute
+        POSIX-style path as required by ``ffmpeg``.
+    output_path:
+        Destination file. Parent directories are created automatically.
+    """
+
+    ordered = sort_clips(clips)
+    _validate_sorted_non_overlapping(ordered)
+
+    video_abs = Path(video_path).resolve()
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    lines = ["ffconcat version 1.0\n"]
+    for clip in ordered:
+        lines.append(f"file '{video_abs.as_posix()}'\n")
+        lines.append(f"inpoint {clip.start:.3f}\n")
+        lines.append(f"outpoint {clip.end:.3f}\n")
+
+    output_path.write_text("".join(lines), encoding="utf-8")
+    logging.debug("Wrote ffconcat with %d clips to %s", len(ordered), output_path)
+
+
+def total_duration(clips: Iterable[Clip]) -> float:
+    """Return the sum of clip durations."""
+
+    return float(sum(max(0.0, c.end - c.start) for c in clips))
+
+
+def ensure_duration_cap(clips: Sequence[Clip], target_seconds: float) -> List[Clip]:
+    """Greedy selection of clips to satisfy a duration cap.
+
+    Clips are processed in descending score order, with ties broken by start
+    time. The resulting playlist preserves chronological order while limiting
+    the total duration to ``target_seconds``.
+    """
+
+    if target_seconds <= 0:
+        return list(clips)
+
+    ordered = list(clips)
+    ordered.sort(key=lambda c: (-c.score, c.start))
+    picked: List[Clip] = []
+    accumulated = 0.0
+    for clip in ordered:
+        duration = clip.duration()
+        if accumulated + duration > target_seconds + 1e-6:
+            continue
+        picked.append(clip)
+        accumulated += duration
+
+    picked.sort(key=lambda c: c.start)
+    try:
+        _validate_sorted_non_overlapping(picked)
+    except ValueError as exc:  # pragma: no cover - defensive logging
+        logging.warning("Duration-cap selection produced overlapping clips: %s", exc)
+    return picked
+
+
+if __name__ == "__main__":  # pragma: no cover - smoke test
+    demo_clips = [
+        Clip(0.0, 5.0, label="BUILDUP", score=10.0),
+        Clip(7.0, 12.5, label="GOAL", score=100.0),
+    ]
+    tmp = Path("/tmp/ffconcat_demo.ffconcat")
+    try:
+        write_ffconcat(demo_clips, Path("/tmp/video.mp4"), tmp)
+        print(tmp.read_text())
+    finally:
+        if tmp.exists():
+            tmp.unlink()

--- a/tools/metrics.py
+++ b/tools/metrics.py
@@ -1,0 +1,119 @@
+"""Metrics utilities for Smart Soccer Highlight Selector."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence
+
+import numpy as np
+import pandas as pd
+
+
+@dataclass
+class Metrics:
+    num_spans: int
+    num_goals_found: int
+    num_shots_found: int
+    num_saves_found: int
+    num_woodwork_found: int
+    total_duration: float
+    avg_in_play_ratio: float
+    coverage_of_resets: float
+    uncovered_resets: List[float]
+
+    def to_json(self) -> str:
+        return json.dumps(self.__dict__, indent=2)
+
+
+def _duration(row: pd.Series) -> float:
+    return float(max(0.0, row["end"] - row["start"]))
+
+
+def compute_metrics(
+    events_df: pd.DataFrame,
+    reset_times: Sequence[float],
+    in_play_ratio: Dict[int, float],
+) -> Metrics:
+    """Compute summary metrics from the final event dataframe."""
+
+    label_counts = events_df["label"].value_counts() if not events_df.empty else pd.Series(dtype=int)
+    num_goals = int(label_counts.get("GOAL", 0))
+    num_shots = int(label_counts.get("SHOT", 0) + label_counts.get("WOODWORK", 0))
+    num_saves = int(label_counts.get("SAVE", 0))
+    num_woodwork = int(label_counts.get("WOODWORK", 0))
+    total_duration = float(events_df.apply(_duration, axis=1).sum()) if not events_df.empty else 0.0
+
+    ratios = list(in_play_ratio.values())
+    avg_ratio = float(np.mean(ratios)) if ratios else 0.0
+
+    uncovered: List[float] = []
+    if reset_times and not events_df.empty:
+        for reset in reset_times:
+            window_end = reset
+            window_start = reset - 25.0
+            window_anchor = reset - 12.0
+            mask = (
+                (events_df["label"] == "GOAL")
+                & (events_df["end"] >= window_anchor)
+                & (events_df["end"] <= window_end)
+                & (events_df["start"] <= window_start)
+            )
+            if mask.sum() == 0:
+                uncovered.append(float(reset))
+
+    coverage = 0.0
+    if reset_times:
+        coverage = 1.0 - len(uncovered) / float(len(reset_times))
+
+    return Metrics(
+        num_spans=int(len(events_df)),
+        num_goals_found=num_goals,
+        num_shots_found=num_shots,
+        num_saves_found=num_saves,
+        num_woodwork_found=num_woodwork,
+        total_duration=total_duration,
+        avg_in_play_ratio=avg_ratio,
+        coverage_of_resets=coverage,
+        uncovered_resets=uncovered,
+    )
+
+
+def write_reports(metrics: Metrics, out_dir: Path) -> None:
+    """Persist metrics to JSON and a human readable text file."""
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "metrics_report.json").write_text(metrics.to_json() + "\n", encoding="utf-8")
+
+    lines = [
+        "Smart Select metrics report\n",
+        "==========================\n",
+        f"Spans exported : {metrics.num_spans}\n",
+        f"Goals detected : {metrics.num_goals_found}\n",
+        f"Shots detected : {metrics.num_shots_found}\n",
+        f"Woodwork hits  : {metrics.num_woodwork_found}\n",
+        f"Saves detected : {metrics.num_saves_found}\n",
+        f"Total duration : {metrics.total_duration:.1f} s\n",
+        f"Avg in-play    : {metrics.avg_in_play_ratio:.3f}\n",
+        f"Goal coverage  : {metrics.coverage_of_resets:.3f}\n",
+    ]
+    if metrics.uncovered_resets:
+        lines.append("\nUncovered goal resets:\n")
+        for reset in metrics.uncovered_resets:
+            lines.append(f"  - Reset @ {reset:.2f}s needs review\n")
+    else:
+        lines.append("\nAll goal resets covered.\n")
+
+    (out_dir / "metrics_readable.txt").write_text("".join(lines), encoding="utf-8")
+
+
+if __name__ == "__main__":  # pragma: no cover - smoke test
+    dummy = pd.DataFrame(
+        [
+            {"label": "GOAL", "start": 10.0, "end": 22.0},
+            {"label": "SHOT", "start": 100.0, "end": 108.0},
+        ]
+    )
+    metrics = compute_metrics(dummy, [40.0], {0: 0.92, 1: 0.96})
+    write_reports(metrics, Path("/tmp/smart_metrics"))
+    print(metrics)

--- a/tools/selector.py
+++ b/tools/selector.py
@@ -1,0 +1,469 @@
+"""Event selection logic for Smart Soccer Highlight Selector."""
+from __future__ import annotations
+
+import dataclasses
+import logging
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+
+from .ffconcat import Clip
+
+
+LABEL_PRIORITY = {"GOAL": 5, "WOODWORK": 4, "SHOT": 3, "SAVE": 2, "BUILDUP": 1}
+TYPE_WEIGHT = {"GOAL": 100.0, "WOODWORK": 90.0, "SHOT": 80.0, "SAVE": 70.0, "BUILDUP": 40.0}
+
+
+@dataclass
+class SelectorConfig:
+    min_clip: float = 3.0
+    max_clip: float = 16.0
+    merge_gap: float = 0.8
+    in_play_min_ratio: float = 0.9
+    goal_pre_range: Tuple[float, float] = (8.0, 14.0)
+    goal_post_range: Tuple[float, float] = (6.0, 9.0)
+    goal_lookback: float = 80.0
+    goal_ahead: float = 1.0
+    shot_pre_range: Tuple[float, float] = (4.0, 8.0)
+    shot_post_range: Tuple[float, float] = (4.0, 6.0)
+    buildup_pre_range: Tuple[float, float] = (3.0, 5.0)
+    buildup_post_range: Tuple[float, float] = (3.0, 5.0)
+    save_pre_range: Tuple[float, float] = (4.0, 6.0)
+    save_post_range: Tuple[float, float] = (4.0, 6.0)
+    audio_peak_threshold: float = 1.0
+    motion_peak_threshold: float = 1.0
+    combined_peak_percentile: float = 85.0
+
+
+@dataclasses.dataclass
+class Candidate:
+    time: float
+    audio_z: float
+    motion_z: float
+    centroid_z: float
+    crowd_z: float
+    combined: float
+    src: str = "detected"
+    label_hint: Optional[str] = None
+
+
+@dataclasses.dataclass
+class EventSpan:
+    label: str
+    start: float
+    end: float
+    score: float
+    src: str
+    notes: str
+    anchor: float
+
+    def to_clip(self) -> Clip:
+        return Clip(self.start, self.end, self.label, self.score)
+
+    def duration(self) -> float:
+        return max(0.0, self.end - self.start)
+
+
+def _robust_z(values: np.ndarray) -> np.ndarray:
+    if values.size == 0:
+        return np.zeros_like(values)
+    median = np.median(values)
+    mad = np.median(np.abs(values - median)) + 1e-6
+    return (values - median) / (1.4826 * mad)
+
+
+def _combine_features(audio_df: pd.DataFrame, motion_df: pd.DataFrame) -> pd.DataFrame:
+    if audio_df.empty and motion_df.empty:
+        return pd.DataFrame(columns=["time"])
+
+    if audio_df.empty:
+        base = motion_df[["time"]].copy()
+    else:
+        base = audio_df[["time"]].copy()
+
+    def _interp(column: str, source: pd.DataFrame) -> np.ndarray:
+        times = base["time"].to_numpy()
+        if column not in source:
+            return np.zeros_like(times)
+        return np.interp(
+            times,
+            source["time"].to_numpy(),
+            source[column].to_numpy(),
+            left=float(source[column].iloc[0]),
+            right=float(source[column].iloc[-1]),
+        )
+
+    for column in ["rms", "rms_smooth", "centroid", "centroid_smooth", "zcr", "crowd_score", "whistle_score"]:
+        if not audio_df.empty:
+            base[column] = _interp(column, audio_df)
+        else:
+            base[column] = 0.0
+
+    for column in ["motion", "motion_smooth", "pan_score"]:
+        if not motion_df.empty:
+            base[column] = _interp(column, motion_df)
+        else:
+            base[column] = 0.0
+
+    base["audio_z"] = _robust_z(base.get("rms_smooth", base.get("rms", pd.Series(0))).to_numpy())
+    base["motion_z"] = _robust_z(base.get("motion_smooth", pd.Series(0)).to_numpy())
+    base["centroid_z"] = _robust_z(base.get("centroid_smooth", base.get("centroid", pd.Series(0))).to_numpy())
+    base["crowd_z"] = _robust_z(base.get("crowd_score", pd.Series(0)).to_numpy())
+    combined = 0.6 * base["audio_z"] + 0.4 * base["motion_z"] + 0.2 * np.clip(base["crowd_z"], 0, None)
+    base["combined"] = combined
+    return base
+
+
+def _find_local_maxima(series: np.ndarray, times: np.ndarray, threshold: float, min_spacing: float) -> List[int]:
+    if series.size < 3:
+        return []
+    indices: List[int] = []
+    last_time = -np.inf
+    for idx in range(1, len(series) - 1):
+        if series[idx] < threshold:
+            continue
+        if times[idx] - last_time < min_spacing:
+            continue
+        if series[idx] > series[idx - 1] and series[idx] >= series[idx + 1]:
+            indices.append(idx)
+            last_time = times[idx]
+    return indices
+
+
+def _range_from_strength(strength: float, base_range: Tuple[float, float]) -> float:
+    low, high = base_range
+    strength = np.clip(strength, 0.0, 5.0)
+    return float(low + (high - low) * (strength / 5.0))
+
+
+class SmartSelector:
+    def __init__(
+        self,
+        audio_df: pd.DataFrame,
+        motion_df: pd.DataFrame,
+        in_play_spans: Sequence[Tuple[float, float]],
+        config: SelectorConfig,
+        prior_events: Optional[pd.DataFrame] = None,
+        goal_resets: Optional[Sequence[float]] = None,
+        forced_goal_marks: Optional[pd.DataFrame] = None,
+    ) -> None:
+        self.timeline = _combine_features(audio_df, motion_df)
+        self.config = config
+        self.in_play_spans = list(sorted(in_play_spans))
+        self.prior_events = prior_events if prior_events is not None else pd.DataFrame()
+        self.goal_resets = list(goal_resets or [])
+        self.forced_goal_marks = forced_goal_marks if forced_goal_marks is not None else pd.DataFrame()
+        self.logger = logging.getLogger("smart_selector")
+        self._last_combined_threshold: Optional[float] = None
+
+    # ------------------------------------------------------------------
+    def _candidate_peaks(self) -> List[Candidate]:
+        if self.timeline.empty:
+            return []
+
+        threshold = np.percentile(self.timeline["combined"], self.config.combined_peak_percentile)
+        times = self.timeline["time"].to_numpy()
+        indices = _find_local_maxima(
+            self.timeline["combined"].to_numpy(),
+            times,
+            max(threshold, self.config.audio_peak_threshold),
+            min_spacing=4.0,
+        )
+        self._last_combined_threshold = max(threshold, self.config.audio_peak_threshold)
+        candidates: List[Candidate] = []
+        for idx in indices:
+            candidates.append(
+                Candidate(
+                    time=float(times[idx]),
+                    audio_z=float(self.timeline.at[idx, "audio_z"]),
+                    motion_z=float(self.timeline.at[idx, "motion_z"]),
+                    centroid_z=float(self.timeline.at[idx, "centroid_z"]),
+                    crowd_z=float(self.timeline.at[idx, "crowd_z"]),
+                    combined=float(self.timeline.at[idx, "combined"]),
+                    src="detected",
+                    label_hint=self._hint_from_priors(times[idx]),
+                )
+            )
+        return candidates
+
+    def _hint_from_priors(self, time_point: float) -> Optional[str]:
+        if self.prior_events.empty:
+            return None
+        window = 3.0
+        close = self.prior_events[
+            (self.prior_events["t0"] <= time_point + window)
+            & (self.prior_events["t1"] >= time_point - window)
+        ]
+        if close.empty:
+            return None
+        labels = close["label"].unique()
+        for label in ["GOAL", "WOODWORK", "SHOT", "SAVE"]:
+            if label in labels:
+                return label
+        return close["label"].iloc[0]
+
+    # ------------------------------------------------------------------
+    def _forced_goal_windows(self) -> List[Tuple[float, float, str]]:
+        windows: List[Tuple[float, float, str]] = []
+        for reset in self.goal_resets:
+            start = max(0.0, float(reset) - self.config.goal_lookback)
+            end = max(0.0, float(reset) - self.config.goal_ahead)
+            windows.append((start, end, f"reset@{reset:.1f}"))
+        if not self.forced_goal_marks.empty:
+            for row in self.forced_goal_marks.itertuples(index=False):
+                if hasattr(row, "t"):
+                    center = float(row.t)
+                elif hasattr(row, "time"):
+                    center = float(row.time)
+                elif hasattr(row, "start"):
+                    center = float(getattr(row, "start"))
+                else:
+                    continue
+                windows.append((max(0.0, center - 20.0), center + 2.0, "forced"))
+        return windows
+
+    def _pick_candidate_in_window(self, candidates: List[Candidate], window: Tuple[float, float, str]) -> Optional[Candidate]:
+        start, end, _ = window
+        pool = [c for c in candidates if start <= c.time <= end]
+        if not pool:
+            return None
+        pool.sort(key=lambda c: (c.combined, c.audio_z, c.motion_z), reverse=True)
+        return pool[0]
+
+    def _score(self, label: str, cand: Candidate, bonus: float = 0.0) -> float:
+        weight = TYPE_WEIGHT.get(label, 10.0)
+        return weight + 5.0 * max(0.0, cand.audio_z) + 5.0 * max(0.0, cand.motion_z) + 2.0 * max(0.0, cand.crowd_z) + bonus
+
+    def _shape_window(self, label: str, cand: Candidate) -> Tuple[float, float]:
+        if label == "GOAL":
+            pre = _range_from_strength(max(cand.audio_z, cand.motion_z), self.config.goal_pre_range)
+            post = _range_from_strength(max(cand.audio_z, cand.motion_z), self.config.goal_post_range)
+        elif label == "WOODWORK":
+            pre = _range_from_strength(cand.audio_z, self.config.shot_pre_range)
+            post = _range_from_strength(cand.audio_z, self.config.shot_post_range)
+        elif label == "SHOT":
+            pre = _range_from_strength(cand.motion_z, self.config.shot_pre_range)
+            post = _range_from_strength(cand.motion_z, self.config.shot_post_range)
+        elif label == "SAVE":
+            pre = _range_from_strength(cand.motion_z, self.config.save_pre_range)
+            post = _range_from_strength(cand.motion_z, self.config.save_post_range)
+        else:
+            pre = _range_from_strength(cand.combined, self.config.buildup_pre_range)
+            post = _range_from_strength(cand.combined, self.config.buildup_post_range)
+        pre = np.clip(pre, 0.5, self.config.max_clip)
+        post = np.clip(post, 0.5, self.config.max_clip)
+        return cand.time - pre, cand.time + post
+
+    def _classify_candidate(self, cand: Candidate) -> str:
+        if cand.label_hint:
+            return cand.label_hint
+        if cand.audio_z > 2.5 and cand.centroid_z > 1.8:
+            return "WOODWORK"
+        if cand.audio_z > 2.3 and cand.motion_z > 1.7:
+            return "SHOT"
+        if cand.motion_z > 2.5 and cand.audio_z > 1.0:
+            return "SAVE"
+        if cand.audio_z > 1.8 or cand.motion_z > 1.5:
+            return "BUILDUP"
+        return "BUILDUP"
+
+    def _deduplicate(self, spans: List[EventSpan]) -> List[EventSpan]:
+        spans = sorted(spans, key=lambda s: s.start)
+        pruned: List[EventSpan] = []
+        for span in spans:
+            keep = True
+            for other in pruned:
+                inter = max(0.0, min(span.end, other.end) - max(span.start, other.start))
+                if inter <= 0:
+                    continue
+                ratio = inter / min(span.duration(), other.duration(), 1e9)
+                if ratio >= 0.9:
+                    if span.score <= other.score:
+                        keep = False
+                        break
+                    else:
+                        pruned.remove(other)
+                        break
+            if keep:
+                pruned.append(span)
+        return pruned
+
+    def _merge_spans(self, spans: List[EventSpan]) -> List[EventSpan]:
+        if not spans:
+            return []
+        spans.sort(key=lambda s: s.start)
+        merged: List[EventSpan] = [spans[0]]
+        for span in spans[1:]:
+            current = merged[-1]
+            if span.start - current.end <= self.config.merge_gap:
+                new_label = current.label if LABEL_PRIORITY[current.label] >= LABEL_PRIORITY[span.label] else span.label
+                new_score = max(current.score, span.score)
+                merged[-1] = EventSpan(
+                    label=new_label,
+                    start=min(current.start, span.start),
+                    end=max(current.end, span.end),
+                    score=new_score,
+                    src=f"{current.src}+{span.src}",
+                    notes=f"{current.notes};{span.notes}".strip(";"),
+                    anchor=current.anchor,
+                )
+            else:
+                merged.append(span)
+        return merged
+
+    def _clamp_span(self, span: EventSpan) -> Tuple[Optional[EventSpan], float]:
+        if not self.in_play_spans:
+            return span, 1.0
+        overlaps: List[Tuple[float, float]] = []
+        for s, e in self.in_play_spans:
+            t0 = max(span.start, s)
+            t1 = min(span.end, e)
+            if t1 - t0 > 0.1:
+                overlaps.append((t0, t1))
+        if not overlaps:
+            ratio = 0.0
+            if span.label == "GOAL":
+                return span, ratio
+            return None, ratio
+
+        total_overlap = sum(e - s for s, e in overlaps)
+        ratio = total_overlap / max(span.duration(), 1e-6)
+
+        if span.label != "GOAL" and ratio < self.config.in_play_min_ratio:
+            return None, ratio
+
+        if span.label == "GOAL":
+            best = None
+            for s, e in overlaps:
+                if s <= span.anchor <= e:
+                    best = (s, e)
+                    break
+            if best is None:
+                best = (overlaps[0][0], overlaps[-1][1])
+            span.start = max(span.start, best[0])
+            span.end = min(span.end, best[1])
+            if span.duration() < self.config.min_clip:
+                span.end = min(span.end + (self.config.min_clip - span.duration()), best[1])
+            return span, ratio
+
+        # Non-goal span: clamp to bounds of largest overlap
+        best = max(overlaps, key=lambda x: x[1] - x[0])
+        span.start = max(span.start, best[0])
+        span.end = min(span.end, best[1])
+        if span.duration() < self.config.min_clip:
+            # Try to expand within original limits
+            needed = self.config.min_clip - span.duration()
+            span.start = max(span.start - needed / 2, span.anchor - self.config.min_clip / 2)
+            span.end = span.start + self.config.min_clip
+        return span, ratio
+
+    def _in_play_ratio(self, span: EventSpan) -> float:
+        if not self.in_play_spans:
+            return 1.0
+        covered = 0.0
+        for s, e in self.in_play_spans:
+            covered += max(0.0, min(span.end, e) - max(span.start, s))
+        return covered / max(span.duration(), 1e-6)
+
+    # ------------------------------------------------------------------
+    def run(self) -> Tuple[pd.DataFrame, List[EventSpan], Dict[int, float]]:
+        candidates = self._candidate_peaks()
+        spans: List[EventSpan] = []
+        used_candidates: set = set()
+
+        for window in self._forced_goal_windows():
+            cand = self._pick_candidate_in_window(candidates, window)
+            notes = window[2]
+            if cand is None:
+                cand = Candidate(
+                    time=float((window[0] + window[1]) / 2.0),
+                    audio_z=0.0,
+                    motion_z=0.0,
+                    centroid_z=0.0,
+                    crowd_z=0.0,
+                    combined=0.0,
+                    src="forced",
+                    label_hint="GOAL",
+                )
+                notes += ":synthetic"
+            else:
+                used_candidates.add(cand.time)
+            start, end = self._shape_window("GOAL", cand)
+            start = max(0.0, start)
+            end = min(start + self.config.max_clip, end)
+            score = self._score("GOAL", cand, bonus=8.0)
+            span = EventSpan("GOAL", start, end, score, src="forced", notes=notes, anchor=cand.time)
+            clamped, ratio = self._clamp_span(span)
+            if clamped is not None:
+                spans.append(clamped)
+
+        for cand in candidates:
+            if cand.time in used_candidates:
+                continue
+            label = self._classify_candidate(cand)
+            start, end = self._shape_window(label, cand)
+            start = max(0.0, start)
+            if end - start > self.config.max_clip:
+                end = start + self.config.max_clip
+            score = self._score(label, cand)
+            span = EventSpan(label, start, end, score, src=cand.src, notes="", anchor=cand.time)
+            clamped, ratio = self._clamp_span(span)
+            if clamped is not None:
+                spans.append(clamped)
+
+        spans = self._merge_spans(spans)
+        spans = self._deduplicate(spans)
+
+        filtered_spans: List[EventSpan] = []
+        ratios_reindexed: Dict[int, float] = {}
+        for idx, span in enumerate(sorted(spans, key=lambda s: s.start)):
+            # enforce min duration
+            if span.duration() < self.config.min_clip:
+                span.end = span.start + self.config.min_clip
+            if span.duration() > self.config.max_clip:
+                span.end = span.start + self.config.max_clip
+            filtered_spans.append(span)
+            ratios_reindexed[idx] = self._in_play_ratio(span)
+
+        rows = [
+            {
+                "label": span.label,
+                "start": round(span.start, 3),
+                "end": round(span.end, 3),
+                "score": round(span.score, 3),
+                "src": span.src,
+                "notes": span.notes,
+            }
+            for span in filtered_spans
+        ]
+        df = pd.DataFrame(rows, columns=["label", "start", "end", "score", "src", "notes"])
+        return df.sort_values("start").reset_index(drop=True), filtered_spans, ratios_reindexed
+
+    @property
+    def last_combined_threshold(self) -> Optional[float]:
+        return self._last_combined_threshold
+
+
+if __name__ == "__main__":  # pragma: no cover - smoke test
+    times = np.linspace(0, 120, 240)
+    audio = pd.DataFrame({
+        "time": times,
+        "rms": np.sin(times / 5.0) ** 2 + 0.2,
+        "rms_smooth": np.sin(times / 5.0) ** 2 + 0.2,
+        "centroid": np.cos(times / 7.0) ** 2,
+        "centroid_smooth": np.cos(times / 7.0) ** 2,
+        "zcr": np.zeros_like(times),
+        "crowd_score": np.sin(times / 5.0) ** 2,
+        "whistle_score": np.zeros_like(times),
+    })
+    motion = pd.DataFrame({
+        "time": times,
+        "motion": np.cos(times / 6.0) ** 2,
+        "motion_smooth": np.cos(times / 6.0) ** 2,
+        "pan_score": np.zeros_like(times),
+    })
+    selector = SmartSelector(audio, motion, [(0.0, 120.0)], SelectorConfig(), goal_resets=[60.0])
+    result, spans, ratios = selector.run()
+    print(result.head())

--- a/tools/signal_features.py
+++ b/tools/signal_features.py
@@ -1,0 +1,275 @@
+"""Signal feature extraction for Smart Soccer Highlight Selector."""
+from __future__ import annotations
+
+import dataclasses
+import logging
+import math
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+try:  # Optional dependency used only when available.
+    import cv2
+except Exception as exc:  # pragma: no cover - handled gracefully at runtime
+    cv2 = None
+    logging.getLogger(__name__).warning("OpenCV is unavailable: %s", exc)
+
+try:  # librosa loads audio straight from video containers via audioread.
+    import librosa
+except Exception as exc:  # pragma: no cover - handled gracefully
+    librosa = None
+    logging.getLogger(__name__).warning("librosa is unavailable: %s", exc)
+
+
+@dataclasses.dataclass
+class AudioFeatureConfig:
+    sr: int = 11_025
+    hop_length: int = 512
+    frame_length: int = 2_048
+    smooth_window_seconds: float = 0.75
+    whistle_band: Tuple[float, float] = (3_500.0, 4_500.0)
+
+
+@dataclasses.dataclass
+class MotionFeatureConfig:
+    sample_stride: int = 3
+    roi: Tuple[float, float, float, float] = (0.2, 0.8, 0.25, 0.75)  # xmin,xmax,ymin,ymax in normalized coords
+    smooth_window_seconds: float = 1.2
+
+
+def _rolling(series: np.ndarray, window: int) -> np.ndarray:
+    if window <= 1:
+        return series
+    pad = window // 2
+    padded = np.pad(series, (pad, pad), mode="edge")
+    kernel = np.ones(window, dtype=float) / float(window)
+    return np.convolve(padded, kernel, mode="valid")
+
+
+def compute_audio_features(video_path: Path, config: Optional[AudioFeatureConfig] = None) -> pd.DataFrame:
+    """Compute audio-derived features from ``video_path``.
+
+    The function is intentionally resilient; if audio cannot be decoded it
+    returns an empty dataframe rather than raising.
+    """
+
+    config = config or AudioFeatureConfig()
+    if librosa is None:
+        logging.warning("Audio features unavailable because librosa could not be imported.")
+        return pd.DataFrame(columns=[
+            "time",
+            "rms",
+            "rms_smooth",
+            "centroid",
+            "centroid_smooth",
+            "zcr",
+            "crowd_score",
+            "whistle_score",
+        ])
+
+    try:
+        signal, sr = librosa.load(str(video_path), sr=config.sr, mono=True)
+    except Exception as exc:  # pragma: no cover - dependent on environment codecs
+        logging.warning("Failed to decode audio from %s: %s", video_path, exc)
+        return pd.DataFrame(columns=[
+            "time",
+            "rms",
+            "rms_smooth",
+            "centroid",
+            "centroid_smooth",
+            "zcr",
+            "crowd_score",
+            "whistle_score",
+        ])
+
+    hop = config.hop_length
+    frame = config.frame_length
+    rms = librosa.feature.rms(y=signal, frame_length=frame, hop_length=hop)[0]
+    centroid = librosa.feature.spectral_centroid(y=signal, sr=sr, n_fft=frame, hop_length=hop)[0]
+    zcr = librosa.feature.zero_crossing_rate(signal, frame_length=frame, hop_length=hop)[0]
+    times = librosa.frames_to_time(np.arange(len(rms)), sr=sr, hop_length=hop)
+
+    smooth_window = max(1, int(config.smooth_window_seconds * sr / hop))
+    rms_smooth = _rolling(rms, smooth_window)
+    centroid_smooth = _rolling(centroid, smooth_window)
+
+    # Crowd excitement proxy: combination of level and centroid slope.
+    centroid_diff = np.gradient(centroid_smooth)
+    crowd_score = np.clip(rms_smooth, 0, None) * np.clip(centroid_diff, 0, None)
+
+    # Whistle proxy: narrow band energy around 3.5-4.5 kHz.
+    n_fft = 2_048
+    stft = librosa.stft(signal, n_fft=n_fft, hop_length=hop, window="hann")
+    freqs = librosa.fft_frequencies(sr=sr, n_fft=n_fft)
+    band_mask = (freqs >= config.whistle_band[0]) & (freqs <= config.whistle_band[1])
+    whistle_energy = np.abs(stft[band_mask]) ** 2
+    whistle_score = whistle_energy.mean(axis=0) if whistle_energy.size else np.zeros_like(rms)
+    whistle_score = _rolling(whistle_score, max(1, smooth_window // 2))
+
+    df = pd.DataFrame(
+        {
+            "time": times.astype(float),
+            "rms": rms.astype(float),
+            "rms_smooth": rms_smooth.astype(float),
+            "centroid": centroid.astype(float),
+            "centroid_smooth": centroid_smooth.astype(float),
+            "zcr": zcr.astype(float),
+            "crowd_score": crowd_score.astype(float),
+            "whistle_score": whistle_score.astype(float),
+        }
+    )
+    return df
+
+
+def compute_motion_features(video_path: Path, config: Optional[MotionFeatureConfig] = None) -> pd.DataFrame:
+    """Compute coarse motion descriptors from the video frames."""
+
+    config = config or MotionFeatureConfig()
+    if cv2 is None:
+        logging.warning("Motion features unavailable because OpenCV could not be imported.")
+        return pd.DataFrame(columns=["time", "motion", "motion_smooth", "pan_score"])
+
+    cap = cv2.VideoCapture(str(video_path))
+    if not cap.isOpened():
+        logging.warning("Failed to open video for motion features: %s", video_path)
+        return pd.DataFrame(columns=["time", "motion", "motion_smooth", "pan_score"])
+
+    fps = cap.get(cv2.CAP_PROP_FPS)
+    if not fps or math.isnan(fps):
+        fps = 25.0
+
+    stride = max(1, config.sample_stride)
+    roi = config.roi
+    records: List[dict] = []
+    prev_gray: Optional[np.ndarray] = None
+    frame_idx = 0
+    while True:
+        ok, frame = cap.read()
+        if not ok:
+            break
+        if frame_idx % stride != 0:
+            frame_idx += 1
+            continue
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        h, w = gray.shape
+        x0 = int(w * roi[0])
+        x1 = int(w * roi[1])
+        y0 = int(h * roi[2])
+        y1 = int(h * roi[3])
+        roi_slice = gray[y0:y1, x0:x1]
+
+        if prev_gray is None:
+            motion_mag = 0.0
+            pan_score = 0.0
+        else:
+            diff = cv2.absdiff(roi_slice, prev_gray[y0:y1, x0:x1])
+            motion_mag = float(diff.mean())
+            global_diff = cv2.absdiff(gray, prev_gray)
+            pan_score = float(np.percentile(global_diff, 95))
+        records.append(
+            {
+                "time": frame_idx / fps,
+                "motion": motion_mag,
+                "pan_score": pan_score,
+            }
+        )
+        prev_gray = gray
+        frame_idx += 1
+
+    cap.release()
+
+    if not records:
+        return pd.DataFrame(columns=["time", "motion", "motion_smooth", "pan_score"])
+
+    df = pd.DataFrame.from_records(records)
+    window = max(1, int(config.smooth_window_seconds * fps / stride))
+    df["motion_smooth"] = _rolling(df["motion"].to_numpy(), window)
+    df["pan_score_smooth"] = _rolling(df["pan_score"].to_numpy(), window)
+    df.rename(columns={"pan_score_smooth": "pan_score"}, inplace=True)
+    return df[["time", "motion", "motion_smooth", "pan_score"]]
+
+
+def interpolate_to(times: np.ndarray, samples_time: np.ndarray, values: np.ndarray) -> np.ndarray:
+    """Interpolate ``values`` sampled at ``samples_time`` to ``times``."""
+
+    if samples_time.size == 0 or values.size == 0:
+        return np.zeros_like(times)
+    return np.interp(times, samples_time, values, left=float(values[0]), right=float(values[-1]))
+
+
+def derive_in_play_mask(
+    audio_df: pd.DataFrame,
+    motion_df: pd.DataFrame,
+    whistle_weight: float = 0.6,
+    min_run: float = 2.0,
+) -> pd.DataFrame:
+    """Infer in-play spans from audio/motion features.
+
+    The method combines smoothed RMS and motion levels and removes sections with
+    dominant whistle energy. It returns a dataframe with ``start`` and ``end``
+    columns marking contiguous in-play intervals.
+    """
+
+    if audio_df.empty and motion_df.empty:
+        return pd.DataFrame(columns=["start", "end"])
+
+    if audio_df.empty:
+        base_times = motion_df["time"].to_numpy()
+        rms = np.zeros_like(base_times)
+        whistle = np.zeros_like(base_times)
+        motion_interp = motion_df["motion_smooth"].to_numpy()
+    else:
+        base_times = audio_df["time"].to_numpy()
+        rms = audio_df.get("rms_smooth", audio_df.get("rms", pd.Series(0))).to_numpy()
+        whistle = audio_df.get("whistle_score", pd.Series(0)).to_numpy()
+        motion_interp = interpolate_to(
+            base_times,
+            motion_df.get("time", pd.Series(dtype=float)).to_numpy(),
+            motion_df.get("motion_smooth", pd.Series(0)).to_numpy(),
+        )
+
+    if base_times.size == 0:
+        return pd.DataFrame(columns=["start", "end"])
+
+    rms_thr = np.percentile(rms, 35) if rms.size else 0.0
+    motion_thr = np.percentile(motion_interp, 35) if motion_interp.size else 0.0
+    whistle_thr = np.percentile(whistle, 75) if whistle.size else np.inf
+
+    active = (rms >= rms_thr) | (motion_interp >= motion_thr)
+    quiet_whistle = whistle < whistle_thr
+    mask = active & quiet_whistle
+
+    spans: List[Tuple[float, float]] = []
+    if mask.any():
+        start_idx = None
+        for i, flag in enumerate(mask):
+            if flag and start_idx is None:
+                start_idx = i
+            elif not flag and start_idx is not None:
+                t0 = float(base_times[start_idx])
+                t1 = float(base_times[i - 1])
+                if t1 - t0 >= min_run:
+                    spans.append((t0, t1))
+                start_idx = None
+        if start_idx is not None:
+            t0 = float(base_times[start_idx])
+            t1 = float(base_times[-1])
+            if t1 - t0 >= min_run:
+                spans.append((t0, t1))
+
+    return pd.DataFrame(spans, columns=["start", "end"])
+
+
+if __name__ == "__main__":  # pragma: no cover - smoke test
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Quick feature extraction smoke test")
+    parser.add_argument("video", type=Path)
+    args = parser.parse_args()
+
+    audio = compute_audio_features(args.video)
+    motion = compute_motion_features(args.video)
+    print(audio.head())
+    print(motion.head())

--- a/tools/smart_select.py
+++ b/tools/smart_select.py
@@ -1,0 +1,335 @@
+"""CLI entry point for the Smart Soccer Highlight Selector pipeline."""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+
+try:  # Support invocation both as module and script.
+    from .ffconcat import Clip, ensure_duration_cap, total_duration, write_ffconcat
+    from .metrics import compute_metrics, write_reports
+    from .selector import SelectorConfig, SmartSelector
+    from .signal_features import (
+        AudioFeatureConfig,
+        MotionFeatureConfig,
+        compute_audio_features,
+        compute_motion_features,
+        derive_in_play_mask,
+    )
+except ImportError:  # pragma: no cover - executed when run as a script.
+    import sys
+
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    from tools.ffconcat import Clip, ensure_duration_cap, total_duration, write_ffconcat
+    from tools.metrics import compute_metrics, write_reports
+    from tools.selector import SelectorConfig, SmartSelector
+    from tools.signal_features import (
+        AudioFeatureConfig,
+        MotionFeatureConfig,
+        compute_audio_features,
+        compute_motion_features,
+        derive_in_play_mask,
+    )
+
+
+def _configure_logging(log_path: Path) -> None:
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        handlers=[logging.FileHandler(log_path, mode="w", encoding="utf-8"), logging.StreamHandler()],
+    )
+
+
+def _read_spans_csv(path: Path) -> List[Tuple[float, float]]:
+    df = pd.read_csv(path)
+    cols = {c.lower(): c for c in df.columns}
+    start_col = cols.get("start") or cols.get("t0") or cols.get("begin")
+    end_col = cols.get("end") or cols.get("t1") or cols.get("stop")
+    if not start_col or not end_col:
+        raise ValueError(f"Could not find start/end columns in {path}")
+    spans: List[Tuple[float, float]] = []
+    for row in df.itertuples(index=False):
+        start = float(getattr(row, start_col))
+        end = float(getattr(row, end_col))
+        if end > start:
+            spans.append((start, end))
+    return spans
+
+
+def _read_events_csv(path: Path) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    cols = {c.lower(): c for c in df.columns}
+    t0 = cols.get("start") or cols.get("t0") or cols.get("begin")
+    t1 = cols.get("end") or cols.get("t1") or cols.get("stop")
+    label_col = cols.get("label") or cols.get("event") or cols.get("type")
+    if t0 and "time" not in cols:
+        df["time"] = (df[t0] + df[t1]) / 2.0 if t1 else df[t0]
+    elif "time" not in df.columns and cols.get("t"):
+        df["time"] = df[cols.get("t")]
+    if label_col:
+        df["label"] = df[label_col].astype(str).str.upper()
+    if t0:
+        df["t0"] = df[t0]
+    if t1:
+        df["t1"] = df[t1]
+    return df
+
+
+def _read_goal_resets(path: Path) -> List[float]:
+    df = pd.read_csv(path)
+    values: List[float] = []
+    for column in df.columns:
+        try:
+            numeric = pd.to_numeric(df[column], errors="coerce")
+        except Exception:
+            continue
+        values.extend(float(v) for v in numeric.dropna())
+        if values:
+            break
+    return sorted(values)
+
+
+def _spans_from_events(events: Sequence[Dict[str, float]]) -> List[Tuple[float, float]]:
+    spans = []
+    for event in events:
+        spans.append((float(event["start"]), float(event["end"])))
+    return spans
+
+
+def _clips_from_spans(spans: Sequence[Dict[str, float]]) -> List[Clip]:
+    return [Clip(float(row["start"]), float(row["end"]), row.get("label", ""), float(row.get("score", 0.0))) for row in spans]
+
+
+def _write_ffconcat_sets(video_path: Path, spans_df: pd.DataFrame, reels_dir: Path, target_cap: float) -> Dict[str, float]:
+    reels_dir.mkdir(parents=True, exist_ok=True)
+    records = spans_df.to_dict("records")
+    clips = _clips_from_spans(records)
+    write_ffconcat(clips, video_path, reels_dir / "all.ffconcat")
+
+    goal_clips = [clip for clip in clips if clip.label == "GOAL"]
+    if goal_clips:
+        write_ffconcat(goal_clips, video_path, reels_dir / "goals.ffconcat")
+    else:
+        (reels_dir / "goals.ffconcat").write_text("ffconcat version 1.0\n", encoding="utf-8")
+
+    shot_labels = {"SHOT", "WOODWORK", "SAVE"}
+    shot_clips = [clip for clip in clips if clip.label in shot_labels]
+    if shot_clips:
+        write_ffconcat(shot_clips, video_path, reels_dir / "shots.ffconcat")
+    else:
+        (reels_dir / "shots.ffconcat").write_text("ffconcat version 1.0\n", encoding="utf-8")
+
+    capped = ensure_duration_cap(clips, target_cap)
+    if capped:
+        write_ffconcat(capped, video_path, reels_dir / "all_capped.ffconcat")
+
+    return {
+        "total_all": total_duration(clips),
+        "total_goals": total_duration(goal_clips),
+        "total_shots": total_duration(shot_clips),
+        "total_capped": total_duration(capped),
+    }
+
+
+def run_pipeline(args: argparse.Namespace) -> None:
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    log_path = out_dir / "log_smart_select.txt"
+    _configure_logging(log_path)
+    logger = logging.getLogger("smart_select")
+
+    video_path = Path(args.video)
+    logger.info("Video: %s", video_path)
+
+    audio_df = compute_audio_features(video_path, AudioFeatureConfig())
+    logger.info("Audio frames: %d", len(audio_df))
+    motion_df = compute_motion_features(video_path, MotionFeatureConfig())
+    logger.info("Motion samples: %d", len(motion_df))
+
+    in_play_spans: List[Tuple[float, float]]
+    if args.in_play:
+        in_play_spans = _read_spans_csv(Path(args.in_play))
+        logger.info("Loaded in-play mask from %s (%d spans)", args.in_play, len(in_play_spans))
+    else:
+        inferred = derive_in_play_mask(audio_df, motion_df)
+        in_play_spans = _spans_from_events(inferred.to_dict("records"))
+        logger.info("Derived in-play mask (%d spans)", len(in_play_spans))
+
+    prior_frames = []
+    goal_resets: List[float] = []
+    forced_goals_df = pd.DataFrame()
+    if args.use_priors:
+        for path in args.use_priors:
+            path_obj = Path(path)
+            if not path_obj.exists():
+                logger.warning("Prior path missing: %s", path)
+                continue
+            if "reset" in path_obj.stem:
+                goal_resets.extend(_read_goal_resets(path_obj))
+                logger.info("Loaded %d goal resets from %s", len(goal_resets), path)
+            elif "forced" in path_obj.stem:
+                forced_goals_df = _read_events_csv(path_obj)
+                logger.info("Loaded forced goal marks: %d", len(forced_goals_df))
+            else:
+                prior_frames.append(_read_events_csv(path_obj))
+        if prior_frames:
+            prior_events = pd.concat(prior_frames, ignore_index=True, sort=False)
+        else:
+            prior_events = pd.DataFrame()
+    else:
+        prior_events = pd.DataFrame()
+
+    goal_resets = sorted(set(goal_resets))
+    logger.info("Goal resets considered: %d", len(goal_resets))
+
+    config = SelectorConfig(min_clip=args.min_clip, max_clip=args.max_clip)
+    selector = SmartSelector(
+        audio_df,
+        motion_df,
+        in_play_spans,
+        config,
+        prior_events=prior_events,
+        goal_resets=goal_resets,
+        forced_goal_marks=forced_goals_df,
+    )
+    events_df, spans, ratios = selector.run()
+    combined_threshold = (
+        selector.last_combined_threshold if selector.last_combined_threshold is not None else float("nan")
+    )
+    logger.info(
+        "Selector thresholds: combined>=%.3f audio_z>=%.2f motion_z>=%.2f",
+        combined_threshold,
+        config.audio_peak_threshold,
+        config.motion_peak_threshold,
+    )
+    logger.info(
+        "Window ranges goal=%s/%s shot=%s/%s save=%s/%s buildup=%s/%s",
+        config.goal_pre_range,
+        config.goal_post_range,
+        config.shot_pre_range,
+        config.shot_post_range,
+        config.save_pre_range,
+        config.save_post_range,
+        config.buildup_pre_range,
+        config.buildup_post_range,
+    )
+    events_path = out_dir / "events_final.csv"
+    events_df.to_csv(events_path, index=False)
+    logger.info("Exported %d events to %s", len(events_df), events_path)
+
+    reels_dir = out_dir / "reels"
+    totals = _write_ffconcat_sets(video_path, events_df, reels_dir, args.target_cap_sec)
+    logger.info("ffconcat totals: %s", totals)
+
+    metrics = compute_metrics(events_df, goal_resets, ratios)
+    write_reports(metrics, out_dir)
+    logger.info("Metrics: %s", metrics)
+
+    summary = {
+        "audio_frames": len(audio_df),
+        "motion_samples": len(motion_df),
+        "combined_threshold": selector.last_combined_threshold,
+        "merge_gap": config.merge_gap,
+        "goal_resets": goal_resets,
+        "totals": totals,
+        "metrics": metrics.__dict__,
+    }
+    (out_dir / "log_smart_select_summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Self tests
+
+
+def _build_synthetic_features(duration: float = 120.0) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    rng = np.random.default_rng(12345)
+    times = np.linspace(0, duration, int(duration * 4))
+    audio = pd.DataFrame({
+        "time": times,
+        "rms": 0.1 + 0.02 * rng.standard_normal(len(times)),
+        "rms_smooth": 0.1 + 0.02 * rng.standard_normal(len(times)),
+        "centroid": 0.2 + 0.03 * rng.standard_normal(len(times)),
+        "centroid_smooth": 0.2 + 0.03 * rng.standard_normal(len(times)),
+        "zcr": np.zeros_like(times),
+        "crowd_score": 0.1 * np.ones_like(times),
+        "whistle_score": np.zeros_like(times),
+    })
+    motion = pd.DataFrame({
+        "time": times,
+        "motion": 0.05 + 0.02 * rng.standard_normal(len(times)),
+        "motion_smooth": 0.05 + 0.02 * rng.standard_normal(len(times)),
+        "pan_score": np.zeros_like(times),
+    })
+    return audio, motion
+
+
+def _self_test_windows() -> None:
+    audio, motion = _build_synthetic_features()
+    audio.loc[(audio["time"] > 40) & (audio["time"] < 41), "rms_smooth"] += 4.0
+    motion.loc[(motion["time"] > 40) & (motion["time"] < 41), "motion_smooth"] += 3.0
+    selector = SmartSelector(audio, motion, [(0.0, 120.0)], SelectorConfig(), goal_resets=[70.0])
+    events_df, spans, ratios = selector.run()
+    assert not events_df.empty, "Expected at least one event"
+    goal = events_df.iloc[0]
+    assert goal["end"] <= 70.0 and goal["start"] <= 45.0, "Goal window should end before reset"
+
+
+def _self_test_goal_coverage() -> None:
+    audio, motion = _build_synthetic_features()
+    audio.loc[(audio["time"] > 20) & (audio["time"] < 21), "rms_smooth"] += 3.5
+    selector = SmartSelector(audio, motion, [(0.0, 120.0)], SelectorConfig(), goal_resets=[55.0])
+    events_df, _, _ = selector.run()
+    assert (events_df["label"] == "GOAL").any(), "Goal coverage expected"
+
+
+def _self_test_in_play_clamp() -> None:
+    audio, motion = _build_synthetic_features()
+    audio.loc[(audio["time"] > 60) & (audio["time"] < 61), "rms_smooth"] += 4.0
+    in_play = [(0.0, 59.0), (62.0, 120.0)]
+    selector = SmartSelector(audio, motion, in_play, SelectorConfig(), goal_resets=[90.0])
+    events_df, spans, _ = selector.run()
+    assert not events_df.empty
+    for span in spans:
+        if span.label != "GOAL":
+            assert span.start >= 62.0 or span.end <= 59.0, "Non-goal span must be clamped to in-play"
+
+
+def run_self_tests() -> None:
+    _self_test_windows()
+    _self_test_goal_coverage()
+    _self_test_in_play_clamp()
+    print("Self-tests passed")
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Smart Soccer Highlight Selector")
+    parser.add_argument("--video", type=Path, help="Path to stabilized match video")
+    parser.add_argument("--out-dir", type=Path, required=True)
+    parser.add_argument("--use-priors", nargs="*", default=[], help="CSV priors to use when scoring")
+    parser.add_argument("--in-play", type=Path, help="Optional in-play CSV")
+    parser.add_argument("--target-cap-sec", type=float, default=360.0)
+    parser.add_argument("--min-clip", type=float, default=3.0)
+    parser.add_argument("--max-clip", type=float, default=16.0)
+    parser.add_argument("--self-test", action="store_true")
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    if args.self_test:
+        run_self_tests()
+        return
+    if not args.video:
+        parser.error("--video is required unless --self-test is used")
+    run_pipeline(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add modular audio/motion feature extraction helpers and in-play estimation utilities
- implement SmartSelector core that scores peaks, shapes highlight windows, clamps to in-play and enforces goal/reset guarantees
- add ffconcat playlist writer, metrics reporting, and smart_select CLI with self-tests plus reel generation helpers

## Testing
- `python tools/smart_select.py --out-dir /tmp/smart --self-test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cf387d3180832d9650d273f8248206