### PR TITLE
Add optical-flow autoframe polynomial generator

### DIFF
--- a/README_AUTOFAME.md
+++ b/README_AUTOFAME.md
@@ -1,0 +1,29 @@
+# Autoframe Polynomial Zooms
+
+This helper analyzes a clip with OpenCV, fits smooth polynomial expressions for
+pans/zoom, and pipes them into the existing FFmpeg crop chain.
+
+## Usage
+
+1. Generate coefficients with Farnebäck motion tracking:
+
+   ```bash
+   python scripts/autoframe.py in.mp4 zoom_coeffs.csv tiktok
+   ```
+
+   * `in.mp4` – source clip to analyze.
+   * `zoom_coeffs.csv` – CSV storing the fitted polynomials (append-only).
+   * `tiktok` – profile label (optional, defaults to `tiktok`).
+
+2. Apply the coefficients during render:
+
+   ```powershell
+   pwsh pipeline/apply_zooms.ps1 -Input in.mp4 -Profile tiktok -Coeffs zoom_coeffs.csv
+   ```
+
+   The script falls back to the baked-in expressions when no matching row is
+   found for the requested clip/profile.
+
+The CSV stores columns `clip`, `profile`, `cx_poly`, `cy_poly`, and `z_poly`,
+where each polynomial uses `n` as the frame index and `n*n` for the quadratic
+term so that the strings can be dropped directly into FFmpeg expressions.

--- a/pipeline/apply_zooms.ps1
+++ b/pipeline/apply_zooms.ps1
@@ -1,0 +1,74 @@
+param(
+  [Parameter(Mandatory=$true)][string]$Input,
+  [string]$Profile = "tiktok",
+  [string]$Coeffs = "./zoom_coeffs.csv",
+  [string]$Output = ""
+)
+
+if (-not (Test-Path $Input)) {
+  throw "Input file not found: $Input"
+}
+
+if ([string]::IsNullOrWhiteSpace($Output)) {
+  $stem = [System.IO.Path]::GetFileNameWithoutExtension($Input)
+  $dir = Split-Path $Input -Parent
+  if (-not $dir) { $dir = "." }
+  $Output = Join-Path $dir "$stem.$Profile.zoom.mp4"
+}
+
+$cxExpr = "(in_w/2)"
+$cyExpr = "(in_h/2)"
+$zExpr  = "1.35"
+
+$name = Split-Path $Input -Leaf
+$row = $null
+if (Test-Path $Coeffs) {
+  $row = Import-Csv $Coeffs | Where-Object { $_.clip -eq $name -and $_.profile -eq $Profile } | Select-Object -First 1
+}
+
+if ($row) {
+  $cxExpr = $row.cx_poly
+  $cyExpr = $row.cy_poly
+  $zExpr  = $row.z_poly
+} else {
+  # fallback: existing linear n-based expressions
+  $cxExpr = "(in_w/2)"
+  $cyExpr = "(in_h/2)"
+  $zExpr  = "1.35"
+}
+
+switch ($Profile.ToLowerInvariant()) {
+  "tiktok" {
+    $targetW = 1080
+    $targetH = 1920
+  }
+  default {
+    $targetW = 1920
+    $targetH = 1080
+  }
+}
+
+$wExpr = "(in_w/($zExpr))"
+$hExpr = "(in_h/($zExpr))"
+$xExpr = "clip(($cxExpr)-(($wExpr)/2),0,in_w-($wExpr))"
+$yExpr = "clip(($cyExpr)-(($hExpr)/2),0,in_h-($hExpr))"
+$clip  = "crop=$wExpr:$hExpr:$xExpr:$yExpr"
+$scale = "scale=$targetW:$targetH"
+$setsar = "setsar=1"
+$format = "format=yuv420p"
+
+$vf = ($clip, $scale, $setsar, $format) -join ","
+
+$ffmpegArgs = @(
+  "-y",
+  "-i", $Input,
+  "-vf", $vf,
+  "-an",
+  "-c:v", "libx264",
+  "-preset", "faster",
+  "-crf", "18",
+  $Output
+)
+
+Write-Host "Running: ffmpeg $($ffmpegArgs -join ' ')"
+ffmpeg @ffmpegArgs

--- a/requirements-autoframe.txt
+++ b/requirements-autoframe.txt
@@ -1,0 +1,2 @@
+opencv-python>=4.9,<5
+numpy>=1.26

--- a/scripts/autoframe.py
+++ b/scripts/autoframe.py
@@ -1,0 +1,129 @@
+"""Generate smooth polynomial zoom coefficients from motion analysis."""
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from fit_utils import MotionBounds, ffmpeg_polyfit, normalized_speed, velocity_clamped_ema
+
+
+def flow_motion_centroid(prev: np.ndarray, curr: np.ndarray) -> tuple[float, float]:
+    """Estimate the dominant motion centroid between two grayscale frames."""
+    flow = cv2.calcOpticalFlowFarneback(prev, curr, None, 0.5, 3, 15, 3, 5, 1.2, 0)
+    mag, _ = cv2.cartToPolar(flow[..., 0], flow[..., 1])
+    mag = cv2.GaussianBlur(mag, (0, 0), 3.0)
+
+    thr = float(np.percentile(mag, 92)) if mag.size else 0.0
+    if np.isfinite(thr) and thr > 0.0:
+        mag = np.where(mag >= thr, mag, 0.0)
+
+    total = float(mag.sum())
+    if total <= 1e-6:
+        h, w = mag.shape
+        return w / 2.0, h / 2.0
+
+    idx = int(np.argmax(mag))
+    y, x = np.unravel_index(idx, mag.shape)
+    return float(x), float(y)
+
+
+def read_motion_paths(video_path: Path) -> tuple[np.ndarray, np.ndarray, int, int]:
+    """Read the video and compute per-frame motion centroids."""
+    cap = cv2.VideoCapture(str(video_path))
+    if not cap.isOpened():
+        raise SystemExit(f"Failed to open input: {video_path}")
+
+    ok, frame = cap.read()
+    if not ok:
+        cap.release()
+        raise SystemExit("Failed to read first frame")
+
+    prev_gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+    height, width = prev_gray.shape
+
+    centers_x = [width / 2.0]
+    centers_y = [height / 2.0]
+
+    while True:
+        ok, frame = cap.read()
+        if not ok:
+            break
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        x, y = flow_motion_centroid(prev_gray, gray)
+        centers_x.append(x)
+        centers_y.append(y)
+        prev_gray = gray
+
+    cap.release()
+
+    cx = np.asarray(centers_x, dtype=np.float64)
+    cy = np.asarray(centers_y, dtype=np.float64)
+    return cx, cy, width, height
+
+
+def compute_zoom_path(cx: np.ndarray, cy: np.ndarray) -> np.ndarray:
+    """Derive a zoom factor path that widens with motion speed."""
+    speed = normalized_speed(cx, cy)
+    zoom = 2.2 - 0.7 * speed
+    return np.clip(zoom, 1.1, 2.2)
+
+
+def save_row(csv_path: Path, row: dict) -> None:
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames = ["clip", "profile", "cx_poly", "cy_poly", "z_poly"]
+    write_header = not csv_path.exists()
+    with csv_path.open("a", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        if write_header:
+            writer.writeheader()
+        writer.writerow(row)
+
+
+def generate_coefficients(input_path: Path, coeffs_path: Path, profile: str = "tiktok") -> dict:
+    cx_raw, cy_raw, width, height = read_motion_paths(input_path)
+    if len(cx_raw) < 6:
+        raise SystemExit("Too few frames for fitting")
+
+    bounds = MotionBounds(width=float(width), height=float(height))
+    cx_smooth = velocity_clamped_ema(cx_raw, vmax=width * 0.012, alpha=0.2)
+    cy_smooth = velocity_clamped_ema(cy_raw, vmax=height * 0.012, alpha=0.2)
+    cx_smooth, cy_smooth = bounds.clamp(cx_smooth, cy_smooth)
+
+    zoom = compute_zoom_path(cx_smooth, cy_smooth)
+
+    row = {
+        "clip": input_path.name,
+        "profile": profile,
+        "cx_poly": ffmpeg_polyfit(cx_smooth, 2),
+        "cy_poly": ffmpeg_polyfit(cy_smooth, 2),
+        "z_poly": ffmpeg_polyfit(zoom, 2),
+    }
+    save_row(coeffs_path, row)
+    return row
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Fit polynomial zoom/crop coefficients")
+    parser.add_argument("input_mp4", type=Path, help="Input MP4 clip")
+    parser.add_argument("coeffs_csv", type=Path, help="Destination CSV for coefficients")
+    parser.add_argument("profile", nargs="?", default="tiktok", help="Profile label")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    row = generate_coefficients(args.input_mp4, args.coeffs_csv, args.profile)
+    print(
+        f"Wrote coefficients for {row['clip']} ({row['profile']}):",
+        row["cx_poly"],
+        row["cy_poly"],
+        row["z_poly"],
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fit_utils.py
+++ b/scripts/fit_utils.py
@@ -1,0 +1,96 @@
+"""Utility helpers for autoframe coefficient fitting."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+import numpy as np
+
+
+@dataclass
+class MotionBounds:
+    """Bounding box for valid motion centers."""
+
+    width: float
+    height: float
+
+    def clamp(self, x: np.ndarray, y: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """Clamp positions to the image bounds."""
+        x_clamped = np.clip(x, 0.0, max(0.0, self.width - 1.0))
+        y_clamped = np.clip(y, 0.0, max(0.0, self.height - 1.0))
+        return x_clamped, y_clamped
+
+
+def velocity_clamped_ema(values: Sequence[float], vmax: float, alpha: float = 0.2) -> np.ndarray:
+    """Smooth a 1-D path with velocity-clamped exponential moving average."""
+    arr = np.asarray(values, dtype=np.float64)
+    if arr.ndim != 1:
+        raise ValueError("values must be a 1-D sequence")
+    if len(arr) == 0:
+        return arr.copy()
+
+    out = np.empty_like(arr)
+    current = arr[0]
+    out[0] = current
+    for i in range(1, len(arr)):
+        delta = arr[i] - current
+        if vmax > 0:
+            delta = np.clip(delta, -vmax, vmax)
+        current = current + delta
+        current = current * (1.0 - alpha) + arr[i] * alpha
+        out[i] = current
+    return out
+
+
+def _format_coeff(value: float) -> str:
+    if abs(value) < 1e-10:
+        return "0"
+    return f"{value:.8g}"
+
+
+def ffmpeg_polyfit(values: Sequence[float], degree: int = 2, var: str = "n") -> str:
+    """Fit a polynomial and format it for FFmpeg expressions."""
+    arr = np.asarray(values, dtype=np.float64)
+    if arr.ndim != 1:
+        raise ValueError("values must be a 1-D sequence")
+    if len(arr) <= degree:
+        raise ValueError("need more samples than polynomial degree")
+
+    n = np.arange(len(arr), dtype=np.float64)
+    coeffs = np.polyfit(n, arr, degree)
+    coeffs = coeffs.tolist()
+    # np.polyfit returns highest degree first.
+    expr = []
+    if degree >= 2:
+        expr.append(f"({_format_coeff(coeffs[0])})*{var}*{var}")
+        expr.append(f"({_format_coeff(coeffs[1])})*{var}")
+        expr.append(f"({_format_coeff(coeffs[2])})")
+    else:
+        for power, coeff in zip(range(degree, -1, -1), coeffs):
+            if power == 0:
+                expr.append(f"({_format_coeff(coeff)})")
+            elif power == 1:
+                expr.append(f"({_format_coeff(coeff)})*{var}")
+            else:
+                expr.append(f"({_format_coeff(coeff)})*{var}^{power}")
+    joined = "+".join(expr)
+    return f"({joined})"
+
+
+def normalized_speed(x: Sequence[float], y: Sequence[float]) -> np.ndarray:
+    """Compute normalized per-frame speed from path coordinates."""
+    arr_x = np.asarray(x, dtype=np.float64)
+    arr_y = np.asarray(y, dtype=np.float64)
+    if arr_x.shape != arr_y.shape:
+        raise ValueError("x and y must have the same shape")
+    if arr_x.ndim != 1:
+        raise ValueError("inputs must be 1-D sequences")
+
+    dx = np.diff(arr_x, prepend=arr_x[0])
+    dy = np.diff(arr_y, prepend=arr_y[0])
+    speed = np.hypot(dx, dy)
+    min_speed = speed.min()
+    spread = speed.max() - min_speed
+    if spread <= 1e-9:
+        return np.zeros_like(speed)
+    return (speed - min_speed) / spread


### PR DESCRIPTION
## Summary
- add an autoframe utility that derives polynomial pan/zoom expressions from Farnebäck optical flow and appends them to a CSV
- share smoothing and polynomial helpers in `scripts/fit_utils.py`
- allow `pipeline/apply_zooms.ps1` to consume the generated coefficients while keeping the crop/scale chain intact
- document the workflow and list the lightweight OpenCV requirements

## Testing
- python -m compileall scripts/autoframe.py scripts/fit_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68d2d594cfb8832d8567c6946d111d9c