### PR TITLE
Add PowerShell driver to run compare pipeline

### DIFF
--- a/Run-Compare.ps1
+++ b/Run-Compare.ps1
@@ -1,0 +1,25 @@
+param(
+  [string]$In    = ".\out\atomic_clips\001__GOAL__t155.50-t166.40.mp4",
+  [string]$Vars  = ".\out\autoframe_work\001__GOAL__t155.50-t166.40_zoom.ps1vars",
+  [string]$Out   = ".\out\reels\tiktok\COMPARE__001__GOAL__t155.50-t166.40.mp4",
+  [string]$VF    = ".\out\autoframe_work\compare_autoframe.vf"
+)
+
+Import-Module "$PSScriptRoot\tools\Autoframe.psm1" -Force
+
+$exprs = Load-ExprVars $Vars
+$E     = Use-FFExprVars -inPath $In -vars $exprs
+
+"--- DEBUG (computed) ---"
+"FPS=$($E.FPS)"
+"W=$($E.W)"
+"H=$($E.H)"
+"X=$($E.X)"
+"Y=$($E.Y)"
+
+$vfText = Write-CompareVF $VF $E
+"--- VF file ---"
+$vfText
+
+Render-Compare $In $VF $Out
+"Done: $Out"


### PR DESCRIPTION
## Summary
- add a Run-Compare.ps1 driver that wires together the Autoframe helpers
- print computed FFmpeg expression parameters, write the .vf script, and launch the render

## Testing
- not run (PowerShell script)

------
https://chatgpt.com/codex/tasks/task_e_68d41a52bcd0832d8ae43dea3fcb6212