### PR TITLE
Refine autoframe helpers and adopt golden Run-Compare pipeline

### DIFF
--- a/Run-Compare.ps1
+++ b/Run-Compare.ps1
@@ -1,13 +1,66 @@
 param(
-  [string]$In  = (Join-Path (Join-Path $PSScriptRoot 'recipes/compare') 'samples/clip.mp4'),
-  [string]$Vars = (Join-Path (Join-Path $PSScriptRoot 'recipes/compare') 'samples/clip_zoom.ps1vars'),
-  [string]$Out  = (Join-Path (Join-Path $PSScriptRoot 'recipes/compare') 'samples/out.mp4'),
-  [string]$VF   = (Join-Path (Join-Path $PSScriptRoot 'recipes/compare') 'samples/tmp.vf')
+  [Parameter(Mandatory=$true)] [string]$In,
+  [Parameter(Mandatory=$true)] [string]$Vars,
+  [Parameter(Mandatory=$true)] [string]$Out,
+  [string]$VF = ".\out\autoframe_work\compare_autoframe.vf",
+  [int]$FPS = 24  # freeze unless you want to auto-detect
 )
 
-$scriptPath = Join-Path $PSScriptRoot 'recipes/compare/Run-Compare.ps1'
-if (-not (Test-Path -LiteralPath $scriptPath)) {
-  throw "Unable to locate recipe runner at $scriptPath"
+Import-Module (Join-Path $PSScriptRoot 'tools/Autoframe.psm1') -Force
+
+# 0) Load fits
+Invoke-Expression (Get-Content -Raw -Encoding UTF8 $Vars)
+if (-not $cxExpr -or -not $cyExpr -or -not $zExpr) {
+  throw "Missing cx/cy/z in $Vars"
 }
 
-& $scriptPath -In $In -Vars $Vars -Out $Out -VF $VF
+# 1) Pre-normalize base exprs (order is important!)
+$cxN = Escape-Commas-In-Parens ( SubN ( Sanitize-Expr ( Expand-Clip $cxExpr ) ) $FPS )
+$cyN = Escape-Commas-In-Parens ( SubN ( Sanitize-Expr ( Expand-Clip $cyExpr ) ) $FPS )
+$zN  = Escape-Commas-In-Parens ( SubN ( Sanitize-Expr ( Expand-Clip $zExpr  ) ) $FPS )
+
+# 2) Build derived exprs (use ih)
+$cwExpr = "((ih*9/16)/($zN))"
+$chExpr = "(ih/($zN))"
+$wExpr  = "floor(($cwExpr)/2)*2"
+$hExpr  = "floor(($chExpr)/2)*2"
+$xCore  = "($cxN)-($wExpr)/2"
+$yCore  = "($cyN)-($hExpr)/2"
+
+# 3) Expand nested $ once
+$expand = { param($s) $ExecutionContext.InvokeCommand.ExpandString($s) }
+$wE = & $expand $wExpr
+$hE = & $expand $hExpr
+$xE = & $expand $xCore
+$yE = & $expand $yCore
+
+# 4) Final safety: escape commas inside parens
+$wE = Escape-Commas-In-Parens $wE
+$hE = Escape-Commas-In-Parens $hE
+$xE = Escape-Commas-In-Parens $xE
+$yE = Escape-Commas-In-Parens $yE
+
+# 5) Write filtergraph (positional crop + ${} so PS doesn’t treat : as drive)
+$vfText = @"
+[0:v]split=2[left][right];
+[right]crop=${wE}:${hE}:${xE}:${yE},scale=-2:1080:flags=lanczos,setsar=1[right_portrait];
+[left][right_portrait]hstack=inputs=2,format=yuv420p
+"@
+[IO.File]::WriteAllText($VF, $vfText, (New-Object Text.UTF8Encoding($false)))
+
+# 6) Log for reproducibility
+"`n--- DEBUG ---" | Write-Host
+"FPS=$FPS" | Write-Host
+"W=$wE" | Write-Host
+"H=$hE" | Write-Host
+"X=$xE" | Write-Host
+"Y=$yE" | Write-Host
+"`n--- VF ($VF) ---" | Write-Host
+(Get-Content $VF) | Write-Host
+
+# 7) Render (keep using -filter_complex_script; deprecation msg is cosmetic)
+ffmpeg -hide_banner -y -nostdin `
+  -i $In `
+  -filter_complex_script $VF `
+  -c:v libx264 -crf 20 -preset veryfast -movflags +faststart -an `
+  $Out

--- a/recipes/compare/Autoframe.psm1
+++ b/recipes/compare/Autoframe.psm1
@@ -86,21 +86,6 @@ function Load-ExprVars {
   [pscustomobject]@{ cx=$cxExpr; cy=$cyExpr; z=$zExpr }
 }
 
-function Sanitize-Expr {
-  param(
-    [Parameter(Mandatory = $true)]
-    [string]$Expression,
-    [Nullable[double]]$Fps
-  )
-
-  $expr = Convert-SciToDecimal -Expression $Expression
-  $expr = ($expr -replace '\s+', '')
-  if ($PSBoundParameters.ContainsKey('Fps') -and $null -ne $Fps) {
-    $expr = SubN -Expression $expr -Fps $Fps
-  }
-  return $expr
-}
-
 function Use-FFExprVars {
   param(
     [Parameter(Mandatory = $true)]
@@ -139,8 +124,10 @@ function Write-CompareVF {
     $E
   )
 
-  $clipX = Expand-Clip -Expression $E.X -Min '0' -Max "iw-($($E.W))"
-  $clipY = Expand-Clip -Expression $E.Y -Min '0' -Max "ih-($($E.H))"
+  $clipXExpr = Expand-Clip -Expression $E.X -Min '0' -Max "iw-($($E.W))"
+  $clipYExpr = Expand-Clip -Expression $E.Y -Min '0' -Max "ih-($($E.H))"
+  $clipX = Escape-Commas-In-Parens (Sanitize-Expr -Expression $clipXExpr)
+  $clipY = Escape-Commas-In-Parens (Sanitize-Expr -Expression $clipYExpr)
   $vfLines = @(
     '[0:v]split=2[left][right];',
     "[right]crop=$($E.W):$($E.H):$clipX:$clipY,scale=-2:1080:flags=lanczos,setsar=1[right_portrait];",

--- a/tools/Autoframe.psm1
+++ b/tools/Autoframe.psm1
@@ -7,8 +7,45 @@ function Convert-SciToDecimal {
     return $Expression
   }
 
-  $pattern = '([0-9]+(?:\.[0-9]+)?)[eE]\+?(-?[0-9]+)'
-  return ([System.Text.RegularExpressions.Regex]::Replace($Expression, $pattern, '($1*pow(10,$2))'))
+  $pattern = '([+-]?\d+(?:\.\d+)?)[eE]([+-]?\d+)'
+  $culture = [System.Globalization.CultureInfo]::InvariantCulture
+  $format = '0.###############################'
+
+  return [System.Text.RegularExpressions.Regex]::Replace(
+    $Expression,
+    $pattern,
+    {
+      param($match)
+      try {
+        $value = [decimal]::Parse($match.Value, [System.Globalization.NumberStyles]::Float, $culture)
+      }
+      catch {
+        $value = [double]::Parse($match.Value, [System.Globalization.NumberStyles]::Float, $culture)
+      }
+      return $value.ToString($format, $culture)
+    }
+  )
+}
+
+function Sanitize-Expr {
+  param(
+    [Parameter(Mandatory = $true)][string]$Expression,
+    [Nullable[double]]$Fps
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Expression)) {
+    return $Expression
+  }
+
+  $expr = $Expression -replace '\,', ','
+  $expr = Convert-SciToDecimal -Expression $expr
+  $expr = ($expr -replace '\s+', '')
+
+  if ($PSBoundParameters.ContainsKey('Fps') -and $null -ne $Fps) {
+    $expr = SubN -Expression $expr -Fps $Fps
+  }
+
+  return $expr
 }
 
 function SubN {
@@ -26,6 +63,156 @@ function SubN {
   return ([System.Text.RegularExpressions.Regex]::Replace($Expression, '\bn\b', "(t*$fpsString)"))
 }
 
+function _Split-TopLevel {
+  param(
+    [Parameter(Mandatory = $true)][string]$Text,
+    [Parameter(Mandatory = $true)][char]$Separator
+  )
+
+  $parts = New-Object System.Collections.Generic.List[string]
+  $builder = [System.Text.StringBuilder]::new()
+  $depth = 0
+
+  foreach ($char in $Text.ToCharArray()) {
+    switch ($char) {
+      '(' {
+        $depth++
+        [void]$builder.Append($char)
+        continue
+      }
+      ')' {
+        if ($depth -gt 0) { $depth-- }
+        [void]$builder.Append($char)
+        continue
+      }
+    }
+
+    if ($char -eq $Separator -and $depth -eq 0) {
+      $parts.Add($builder.ToString()) | Out-Null
+      $builder.Length = 0
+      continue
+    }
+
+    [void]$builder.Append($char)
+  }
+
+  $parts.Add($builder.ToString()) | Out-Null
+  return $parts.ToArray()
+}
+
+function _Parse-ClipInvocation {
+  param(
+    [Parameter(Mandatory = $true)][string]$Text,
+    [Parameter(Mandatory = $true)][int]$OpenParenIndex
+  )
+
+  $length = $Text.Length
+  if ($OpenParenIndex -lt 0 -or $OpenParenIndex -ge $length) {
+    return $null
+  }
+
+  if ($Text[$OpenParenIndex] -ne '(') {
+    return $null
+  }
+
+  $depth = 1
+  $pos = $OpenParenIndex + 1
+
+  while ($pos -lt $length -and $depth -gt 0) {
+    $char = $Text[$pos]
+    if ($char -eq '(') { $depth++ }
+    elseif ($char -eq ')') { $depth-- }
+    $pos++
+  }
+
+  if ($depth -ne 0) {
+    return $null
+  }
+
+  $start = $OpenParenIndex + 1
+  $innerLength = $pos - $start - 1
+  if ($innerLength -lt 0) { $innerLength = 0 }
+  $inner = if ($innerLength -gt 0) { $Text.Substring($start, $innerLength) } else { '' }
+  $args = _Split-TopLevel -Text $inner -Separator ','
+  for ($i = 0; $i -lt $args.Length; $i++) {
+    $args[$i] = $args[$i].Trim()
+  }
+
+  [pscustomobject]@{
+    Args = $args
+    NextIndex = $pos
+  }
+}
+
+function _Rewrite-ClipExpression {
+  param(
+    [Parameter(Mandatory = $true)][string]$Text
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Text)) {
+    return $Text
+  }
+
+  $builder = [System.Text.StringBuilder]::new()
+  $length = $Text.Length
+  $index = 0
+
+  while ($index -lt $length) {
+    $remaining = $length - $index
+    if ($remaining -ge 4) {
+      $segment = $Text.Substring($index, 4)
+      if ($segment.Equals('clip', [System.StringComparison]::OrdinalIgnoreCase)) {
+        $prevIndex = $index - 1
+        $prevValid = ($prevIndex -lt 0) -or -not ([char]::IsLetterOrDigit($Text[$prevIndex]) -or $Text[$prevIndex] -eq '_')
+        $probe = $index + 4
+        while ($probe -lt $length -and [char]::IsWhiteSpace($Text[$probe])) { $probe++ }
+        if ($prevValid -and $probe -lt $length -and $Text[$probe] -eq '(') {
+          $parsed = _Parse-ClipInvocation -Text $Text -OpenParenIndex $probe
+          if ($null -ne $parsed -and $parsed.Args.Length -eq 3) {
+            $valueExpr = _Rewrite-ClipExpression $parsed.Args[0]
+            $minExpr = _Rewrite-ClipExpression $parsed.Args[1]
+            $maxExpr = _Rewrite-ClipExpression $parsed.Args[2]
+            $replacement = "min(max(($valueExpr),($minExpr)),($maxExpr))"
+            [void]$builder.Append($replacement)
+            $index = $parsed.NextIndex
+            continue
+          }
+        }
+      }
+    }
+
+    [void]$builder.Append($Text[$index])
+    $index++
+  }
+
+  return $builder.ToString()
+}
+
+function Expand-Clip {
+  param(
+    [Parameter(Mandatory = $true, Position = 0)][string]$Expression,
+    [string]$Min,
+    [string]$Max
+  )
+
+  if ($PSBoundParameters.ContainsKey('Min') -or $PSBoundParameters.ContainsKey('Max')) {
+    if (-not ($PSBoundParameters.ContainsKey('Min') -and $PSBoundParameters.ContainsKey('Max'))) {
+      throw 'Expand-Clip requires both Min and Max when one is provided.'
+    }
+
+    $inner = if ([string]::IsNullOrWhiteSpace($Expression)) { '0' } else { $Expression }
+    $minExpr = if ([string]::IsNullOrWhiteSpace($Min)) { '0' } else { $Min }
+    $maxExpr = if ([string]::IsNullOrWhiteSpace($Max)) { '0' } else { $Max }
+    $Expression = "clip(($inner),$minExpr,$maxExpr)"
+  }
+
+  if ([string]::IsNullOrWhiteSpace($Expression)) {
+    return $Expression
+  }
+
+  return _Rewrite-ClipExpression -Text $Expression
+}
+
 function Escape-Commas-In-Parens {
   param(
     [Parameter(Mandatory = $true)][string]$Text
@@ -37,6 +224,7 @@ function Escape-Commas-In-Parens {
 
   $builder = [System.Text.StringBuilder]::new()
   $depth = 0
+
   foreach ($char in $Text.ToCharArray()) {
     switch ($char) {
       '(' {
@@ -50,7 +238,7 @@ function Escape-Commas-In-Parens {
         continue
       }
       ',' {
-        if ($depth -eq 1) {
+        if ($depth -gt 0) {
           [void]$builder.Append('\,')
         }
         else {
@@ -67,23 +255,9 @@ function Escape-Commas-In-Parens {
   return $builder.ToString()
 }
 
-function Expand-Clip {
-  param(
-    [Parameter(Mandatory = $true)][string]$Expression,
-    [Parameter(Mandatory = $true)][string]$Min,
-    [Parameter(Mandatory = $true)][string]$Max
-  )
-
-  $inner = if ([string]::IsNullOrWhiteSpace($Expression)) { '0' } else { $Expression }
-  $minExpr = if ([string]::IsNullOrWhiteSpace($Min)) { '0' } else { $Min }
-  $maxExpr = if ([string]::IsNullOrWhiteSpace($Max)) { '0' } else { $Max }
-
-  $clip = "clip(($inner),$minExpr,$maxExpr)"
-  return Escape-Commas-In-Parens -Text $clip
-}
-
 Export-ModuleMember -Function \
   Convert-SciToDecimal, \
+  Sanitize-Expr, \
   SubN, \
-  Escape-Commas-In-Parens, \
-  Expand-Clip
+  Expand-Clip, \
+  Escape-Commas-In-Parens


### PR DESCRIPTION
## Summary
- replace the top-level Run-Compare script with the golden pipeline that normalizes expressions and renders the compare clip
- expand the autoframe helper module with sanitize, clip rewriting, and comma escaping utilities used by the pipeline
- adjust the compare recipe module to consume the updated helpers when writing filter graphs

## Testing
- Not run (PowerShell not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68d4277b03ec832db1cd6131e7f1de9c