### PR TITLE
Fix Run-Compare batch crop expression handling

### DIFF
--- a/scripts/run-compare-batch.ps1
+++ b/scripts/run-compare-batch.ps1
@@ -1,8 +1,10 @@
 # ==== Run-Compare-Batch.ps1 ====
 # Requires: ffmpeg/ffprobe in PATH, your per-clip *.ps1vars files
 
-# --- Make paths independent of current dir ---
+# --- Stable roots/dirs ---
+$ErrorActionPreference = 'Stop'
 $Root    = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$ffmpeg  = 'ffmpeg'
 $inDir   = Join-Path $Root 'out\atomic_clips'
 $varsDir = Join-Path $Root 'out\autoframe_work'
 $outDir  = Join-Path $Root 'out\reels\tiktok'
@@ -27,12 +29,15 @@ function Convert-SciToDecimal([string]$s) {
     ($base * [math]::Pow(10,$exp)).ToString("0.############################", [Globalization.CultureInfo]::InvariantCulture)
   })
 }
-function Sanitize([string]$s) { ($s -replace '\s+','') | Convert-SciToDecimal }
+function Sanitize([string]$s) { Convert-SciToDecimal (($s -replace '\s+','')) }
 function SubN([string]$s, [int]$fps) { $s -replace '\bn\b', "(t*$fps)" }
 function Expand-Clip([string]$s) {
   $pat = 'clip\((?<v>(?>[^()]+|\((?<o>)|\)(?<-o>))*(?(o)(?!))),(?<a>(?>[^()]+|\((?<o2>)|\)(?<-o2>))*(?(o2)(?!))),(?<b>(?>[^()]+|\((?<o3>)|\)(?<-o3>))*(?(o3)(?!)))\)'
   while ($s -match $pat) {
-    $s = [regex]::Replace($s, $pat, { param($m) "min(max($($m.Groups['v'].Value),$($m.Groups['a'].Value)),$($m.Groups['b'].Value))" })
+    $s = [regex]::Replace($s, $pat, {
+      param($m)
+      "min(max($($m.Groups['v'].Value),$($m.Groups['a'].Value)),$($m.Groups['b'].Value))"
+    })
   }
   $s
 }
@@ -62,34 +67,40 @@ Get-ChildItem $inDir -File -Filter "*.mp4" | ForEach-Object {
   Invoke-Expression (Get-Content -Raw -Encoding UTF8 $vars)
   if (-not $cxExpr -or -not $cyExpr -or -not $zExpr) { Write-Warning "Bad vars in $vars"; return }
 
-  # normalize expressions (cx, cy, z)
+  # Assume you've set $fps (fallback to 24 if not present)
+  if (-not $fps) { $fps = 24 }
+
+  # Normalize cx, cy, z (expand clip -> sanitize -> replace n -> escape commas)
   $cxN = Escape-Commas-In-Parens ( SubN ( Sanitize ( Expand-Clip $cxExpr ) ) $fps )
   $cyN = Escape-Commas-In-Parens ( SubN ( Sanitize ( Expand-Clip $cyExpr ) ) $fps )
   $zN  = Escape-Commas-In-Parens ( SubN ( Sanitize ( Expand-Clip $zExpr  ) ) $fps )
 
-  # build crop expressions (named args; ih/iw; even dims)
-  $w  = "floor((((ih*9/16)/($zN)))/2)*2"
-  $h  = "floor(((ih/($zN)))/2)*2"
-  $x  = "($cxN)-($w)/2"
-  $y  = "($cyN)-($h)/2"
+  # Build portrait crop window (use ih/iw; even sizes)
+  $w = "floor((((ih*9/16)/($zN)))/2)*2"
+  $h = "floor(((ih/($zN)))/2)*2"
+  $x = "($cxN)-($w)/2"
+  $y = "($cyN)-($h)/2"
 
-  # final escaping pass for any commas introduced by min/max
+  # Final escape (min/max can introduce commas)
   $w = Escape-Commas-In-Parens $w
   $h = Escape-Commas-In-Parens $h
   $x = Escape-Commas-In-Parens $x
   $y = Escape-Commas-In-Parens $y
 
-  # final filter (right = portrait crop; left = original; hstack)
-  $vf = "[0:v]split=2[left][right];" +
-        "[right]crop=w='$w':h='$h':x='$x':y='$y',scale=w=-2:h=1080:flags=lanczos,setsar=1[right_portrait];" +
-        "[left][right_portrait]hstack=inputs=2,format=yuv420p"
+  # Named crop args + single quotes
+  $filter = "[0:v]crop=w='$w':h='$h':x='$x':y='$y',scale=w=-2:h=1080:flags=lanczos,setsar=1,format=yuv420p"
 
+  # Input/output paths
   $inPath  = Join-Path $inDir  $_.Name
   $outPath = Join-Path $outDir ("COMPARE__" + $stem + ".mp4")
 
+  if (-not (Test-Path $inPath)) { Write-Warning "Missing input: $inPath"; return }
   Write-Host "`n>> Processing $($_.Name)  (fps=$fps)"
-  & ffmpeg -hide_banner -y -nostdin -i $inPath -filter_complex $vf `
+  Write-Host ">> filter: $filter"
+
+  & $ffmpeg -hide_banner -y -nostdin -i $inPath -filter_complex $filter `
     -c:v libx264 -crf 20 -preset veryfast -movflags +faststart -an $outPath
+  if ($LASTEXITCODE -ne 0) { throw "ffmpeg failed on $($_.Name)" }
 }
 
 Write-Host "`nAll done."


### PR DESCRIPTION
## Summary
- normalize crop math expressions by expanding clip(), sanitizing, and escaping commas before composing named crop arguments
- emit a single crop-based filter chain and use a configurable ffmpeg path with error checking for each processed clip

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d44578fa40832d8a69db61b77c371f