### PR TITLE
Update run-compare-batch helpers and filter build

### DIFF
--- a/scripts/run-compare-batch.ps1
+++ b/scripts/run-compare-batch.ps1
@@ -11,7 +11,13 @@ $varsDir = (Resolve-Path (Join-Path $Root 'out\autoframe_work')).Path
 $outDir  = Join-Path $Root 'out\reels\tiktok'
 New-Item -Force -ItemType Directory $outDir | Out-Null
 
-# --- Helpers (replace your existing ones with these) ---
+# --- helpers (self-contained, no session priming needed) ---
+function Unquote([string]$s) {
+  if ($null -eq $s) { return $s }
+  if ($s -match '^\s*"(.*)"\s*$') { return $Matches[1] }
+  if ($s -match "^\s*'(.*)'\s*$") { return $Matches[1] }
+  return $s
+}
 function Convert-SciToDecimal([string]$s) {
   $pat = '([+-]?(?:\d+(?:\.\d+)?|\.\d+))[eE]([+-]?\d+)'
   [regex]::Replace($s, $pat, {
@@ -21,109 +27,54 @@ function Convert-SciToDecimal([string]$s) {
     ($base * [math]::Pow(10,$exp)).ToString("0.############################",[Globalization.CultureInfo]::InvariantCulture)
   })
 }
-function Sanitize-Expr([string]$s) {
-  $s = $s -replace '\s+',''
-  Convert-SciToDecimal $s
-}
+function Sanitize-Expr([string]$s) { Convert-SciToDecimal ($s -replace '\s+','') }
 function SubN([string]$s, [int]$fps) { $s -replace '\bn\b', "(t*$fps)" }
-
-# Unescape any historical '\\,' so 'clip(v\\,a\\,b)' becomes 'clip(v,a,b)'
 function Unescape-Expr([string]$s) { $s -replace '\\,', ',' }
-
-# Split a string on commas at depth 0 (ignoring nested parens)
-function Split-TopLevel([string]$text) {
-  $parts   = @()
-  $current = [System.Text.StringBuilder]::new()
-  $depth   = 0
-
-  foreach ($ch in $text.ToCharArray()) {
-    switch ($ch) {
-      '(' { $depth++; [void]$current.Append($ch); continue }
-      ')' { if ($depth -gt 0) { $depth-- }; [void]$current.Append($ch); continue }
-      ',' {
-        if ($depth -eq 0) {
-          $parts += $current.ToString()
-          [void]$current.Clear()
-          continue
-        }
+function Replace-ClipByScan([string]$s) {
+  $s = $s -replace '\\,', ','
+  $sb = [System.Text.StringBuilder]::new()
+  $i = 0
+  while ($i -lt $s.Length) {
+    if ($i -le $s.Length-5 -and $s.Substring($i,5) -eq 'clip(') {
+      $i += 5; $depth = 1; $inner = [System.Text.StringBuilder]::new()
+      while ($i -lt $s.Length -and $depth -gt 0) {
+        $ch = $s[$i]; if ($ch -eq '(') { $depth++ } elseif ($ch -eq ')') { $depth-- }
+        if ($depth -gt 0) { $null = $inner.Append($ch) }; $i++
       }
-    }
-    [void]$current.Append($ch)
-  }
-
-  $parts += $current.ToString()
-  return $parts
-}
-
-function Replace-ClipByScan([string]$text) {
-  if ([string]::IsNullOrWhiteSpace($text)) { return $text }
-
-  $builder = [System.Text.StringBuilder]::new()
-  $length  = $text.Length
-  $index   = 0
-
-  while ($index -lt $length) {
-    if ($index -le $length - 4) {
-      $segment = $text.Substring($index, 4)
-      if ($segment.Equals('clip', [System.StringComparison]::OrdinalIgnoreCase)) {
-        $prevIndex = $index - 1
-        $prevValid = ($prevIndex -lt 0) -or -not ([char]::IsLetterOrDigit($text[$prevIndex]) -or $text[$prevIndex] -eq '_')
-        $probe = $index + 4
-        while ($probe -lt $length -and [char]::IsWhiteSpace($text[$probe])) { $probe++ }
-        if ($prevValid -and $probe -lt $length -and $text[$probe] -eq '(') {
-          $depth = 1
-          $pos   = $probe + 1
-          while ($pos -lt $length -and $depth -gt 0) {
-            $ch = $text[$pos]
-            if ($ch -eq '(') { $depth++ }
-            elseif ($ch -eq ')') { $depth-- }
-            $pos++
-          }
-
-          if ($depth -eq 0) {
-            $argsText = if ($pos -gt $probe + 1) { $text.Substring($probe + 1, $pos - $probe - 2) } else { '' }
-            $args = Split-TopLevel $argsText
-            if ($args.Count -eq 3) {
-              $valueExpr = Replace-ClipByScan ($args[0].Trim())
-              $minExpr   = Replace-ClipByScan ($args[1].Trim())
-              $maxExpr   = Replace-ClipByScan ($args[2].Trim())
-              $replacement = "min(max(($valueExpr),($minExpr)),($maxExpr))"
-              [void]$builder.Append($replacement)
-              $index = $pos
-              continue
-            }
-          }
-        }
+      $inner = $inner.ToString()
+      $lvl = 0; $first = -1; $second = -1
+      for ($j=0; $j -lt $inner.Length; $j++) {
+        $c = $inner[$j]
+        if ($c -eq '(') { $lvl++ } elseif ($c -eq ')') { $lvl-- }
+        elseif ($c -eq ',' -and $lvl -eq 0) { if ($first -lt 0) { $first=$j } elseif ($second -lt 0) { $second=$j; break } }
       }
-    }
-
-    [void]$builder.Append($text[$index])
-    $index++
+      if ($first -lt 0 -or $second -lt 0) { throw "Could not parse clip(): $inner" }
+      $v = $inner.Substring(0,$first); $a=$inner.Substring($first+1,$second-$first-1); $b=$inner.Substring($second+1)
+      $null = $sb.Append("min(max($v,$a),$b)")
+    } else { $null = $sb.Append($s[$i]); $i++ }
   }
-
-  return $builder.ToString()
+  $sb.ToString()
 }
-
-# clip(v,a,b)  ->  min(max(v,a), b)   (supports nesting)
-function Expand-Clip([string]$s) {
-  # Safe to assume commas are unescaped now
-  $pat = 'clip\((?<v>(?>[^()]+|\((?<o>)|\)(?<-o>))*(?(o)(?!))),(?<a>(?>[^()]+|\((?<o2>)|\)(?<-o2>))*(?(o2)(?!))),(?<b>(?>[^()]+|\((?<o3>)|\)(?<-o3>))*(?(o3)(?!)))\)'
-  while ($s -match $pat) {
-    $s = [regex]::Replace($s, $pat, {
-      param($m)
-      "min(max($($m.Groups['v'].Value),$($m.Groups['a'].Value)),$($m.Groups['b'].Value))"
-    })
-  }
-  $s
-}
-
-# One-stop normalization used for cx, cy, z
 function Normalize([string]$s, [int]$fps) {
   $s = Unescape-Expr $s
-  $s = Expand-Clip   $s
   $s = Sanitize-Expr $s
-  $s = SubN          $s $fps
-  return $s
+  $s = SubN $s $fps
+  $s
+}
+function Get-VarLine([string]$text, [string]$name) {
+  $pat = '(?m)^\s*\$?' + [regex]::Escape($name) + '\s*=\s*(.+?)\s*$'
+  $m = [regex]::Match($text, $pat)
+  if ($m.Success) { $m.Groups[1].Value } else { $null }
+}
+function Load-ZoomVars([string]$varsPath) {
+  if (-not (Test-Path $varsPath)) { return $null }
+  $raw = Get-Content -Raw -Encoding UTF8 $varsPath
+  $raw = $raw -replace "^\uFEFF","" -replace "\u200B|\u200E|\u200F",""
+  $cxExpr = Unquote (Get-VarLine $raw 'cxExpr'); if (-not $cxExpr) { $cxExpr = Unquote (Get-VarLine $raw 'cx') }
+  $cyExpr = Unquote (Get-VarLine $raw 'cyExpr'); if (-not $cyExpr) { $cyExpr = Unquote (Get-VarLine $raw 'cy') }
+  $zExpr  = Unquote (Get-VarLine $raw 'zExpr' ); if (-not $zExpr ) { $zExpr  = Unquote (Get-VarLine $raw 'z' ) }
+  if (-not $cxExpr -or -not $cyExpr -or -not $zExpr) { return $null }
+  [pscustomobject]@{ cxExpr=$cxExpr; cyExpr=$cyExpr; zExpr=$zExpr }
 }
 
 # -- loop all atomic clips
@@ -133,52 +84,23 @@ Get-ChildItem $inDir -File -Filter "*.mp4" | ForEach-Object {
   # map:  "...\X__NAME__tA-tB.mp4"  ->  "...\X__NAME__tA-tB_zoom.ps1vars"
   $stem     = [IO.Path]::GetFileNameWithoutExtension($_.Name)
   $varsPath = Join-Path $varsDir ($stem + "_zoom.ps1vars")
-  # --- Load fit vars robustly ---
-  if (-not (Test-Path $varsPath)) {
-    Write-Warning "No vars for $($_.Name) -> $varsPath"
-    return
-  }
+  $vars = Load-ZoomVars $varsPath
+  if ($null -eq $vars) { throw "Missing cxExpr/cyExpr/zExpr in $varsPath" }
 
-  # --- Robust loader for cxExpr/cyExpr/zExpr from $varsPath
-  Remove-Variable cxExpr,cyExpr,zExpr,cx,cy,z -ErrorAction SilentlyContinue
+  Write-Host "Loaded:`n cxExpr=$($vars.cxExpr)`n cyExpr=$($vars.cyExpr)`n zExpr=$($vars.zExpr)" -ForegroundColor DarkCyan
 
-  $raw = Get-Content -Raw -Encoding UTF8 $varsPath
-  $raw = $raw -replace "^\uFEFF","" -replace "\u200B|\u200E|\u200F",""
+  $fps = [int]24  # lock if your ingest is always 24
+  $zN  = Normalize $($vars.zExpr)  $fps
+  $cxN = Normalize $($vars.cxExpr) $fps
+  $cyN = Normalize $($vars.cyExpr) $fps
 
-  function Get-VarLine([string]$text, [string]$name) {
-    # Build regex without letting PowerShell expand $?
-    $pat = '(?m)^\s*\$?' + [regex]::Escape($name) + '\s*=\s*(.+?)\s*$'
-    $m = [regex]::Match($text, $pat)
-    if ($m.Success) { $m.Groups[1].Value } else { $null }
-  }
+  $w = "floor(((ih*9/16)/($zN))/2)*2"
+  $h = "floor((ih/($zN))/2)*2"
+  $x = "($cxN)-($w)/2"
+  $y = "($cyN)-($h)/2"
 
-  $cxExpr = Get-VarLine $raw 'cxExpr'; if (-not $cxExpr) { $cxExpr = Get-VarLine $raw 'cx' }
-  $cyExpr = Get-VarLine $raw 'cyExpr'; if (-not $cyExpr) { $cyExpr = Get-VarLine $raw 'cy' }
-  $zExpr  = Get-VarLine $raw 'zExpr' ; if (-not $zExpr ) { $zExpr  = Get-VarLine $raw 'z'  }
-
-  $missing = @()
-  foreach ($n in 'cxExpr','cyExpr','zExpr') {
-    if (-not (Get-Variable $n -ValueOnly -ErrorAction SilentlyContinue)) { $missing += $n }
-  }
-  if ($missing.Count) { throw "Missing $($missing -join '/')" + " in $varsPath" }
-
-  Write-Host "Loaded:`n cxExpr=$cxExpr`n cyExpr=$cyExpr`n zExpr=$zExpr" -ForegroundColor DarkCyan
-
-  $fps = 24  # lock if your ingest is always 24
-
-  # normalize first (this kills clip(), sci notation, and n->t*fps)
-  $zN  = Normalize $zExpr  $fps
-  $cxN = Normalize $cxExpr $fps
-  $cyN = Normalize $cyExpr $fps
-
-  # build expressions (portrait 9:16 viewport width derived from ih)
-  $w   = "floor(((ih*9/16)/($zN))/2)*2"
-  $h   = "floor((ih/($zN))/2)*2"
-  $x   = "($cxN)-($w)/2"
-  $y   = "($cyN)-($h)/2"
-
-  # assemble the final filter string (named args; each quoted)
   $filter = "[0:v]crop=w='$w':h='$h':x='$x':y='$y',scale=w=-2:h=1080:flags=lanczos,setsar=1,format=yuv420p"
+  $filter = Replace-ClipByScan $filter   # remove any lingering clip()
 
   # --- IO paths ---
   $inPath  = Join-Path $inDir  $_.Name
@@ -189,7 +111,6 @@ Get-ChildItem $inDir -File -Filter "*.mp4" | ForEach-Object {
   Write-Host ">> filter: $filter"
 
   # run ffmpeg (inline filter avoids the script-file quoting mess)
-  $filter = Replace-ClipByScan $filter
   if ($filter -match 'clip\(') { throw 'clip() still present after expansion' }
   & $ffmpeg -hide_banner -y -nostdin `
     -i $inPath `


### PR DESCRIPTION
## Summary
- replace the Run-Compare-Batch helper functions with the new normalized implementations
- use Load-ZoomVars to load zoom expressions and build the crop filter with Replace-ClipByScan

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d465b50fa4832dabec36f0e442d111