### PR TITLE
Adjust zoom response to speed and fix warning dash

### DIFF
--- a/scripts/run-compare-batch.ps1
+++ b/scripts/run-compare-batch.ps1
@@ -118,11 +118,11 @@ Get-ChildItem $inDir -File -Filter "*.mp4" | ForEach-Object {
   if ($null -eq $vars) {
     if ($DefaultIfMissing) {
       $vars = [pscustomobject]@{ cxExpr='iw/2'; cyExpr='ih/2'; zExpr='1.10' }
-      Write-Warning "No vars for $name — using defaults"
+      Write-Warning "No vars for $name - using defaults"
       $Defaulted++
     }
     elseif ($SkipMissingVars) {
-      Write-Warning "No vars for $name — skipping"
+      Write-Warning "No vars for $name - skipping"
       $Skipped++
       return
     }
@@ -150,7 +150,7 @@ Get-ChildItem $inDir -File -Filter "*.mp4" | ForEach-Object {
   $cyAgg = "($cyN)+($LeadFrames)*($cypN)"
 
   $speed = "sqrt(($cxpN)*($cxpN)+($cypN)*($cypN))"
-  $zAgg  = "min(max((($zN)-($kSpeed)*($speed)),$zMin),$zMax)"
+  $zAgg  = "min(max((($zN)+($kSpeed)*($speed)),$zMin),$zMax)"
 
   $w = "floor(((ih*9/16)/($zAgg))/2)*2"
   $h = "floor((ih/($zAgg))/2)*2"


### PR DESCRIPTION
## Summary
- increase the zoom factor when motion speed increases by adding the speed term instead of subtracting it in the autoframe filter
- replace the em dash in the missing-vars warning with a plain hyphen to avoid encoding issues

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4886758d8832d994d0257bb84498b