### PR TITLE
Tune zoom defaults and bias

### DIFF
--- a/scripts/run-compare-batch.ps1
+++ b/scripts/run-compare-batch.ps1
@@ -2,10 +2,11 @@ param(
   [switch]$SkipMissingVars = $true,
   [switch]$DefaultIfMissing = $true,
   [int]$Fps = 24,
-  [double]$kSpeed = 0.004,
-  [int]$LeadFrames = 3,
-  [double]$zMin = 1.08,
-  [double]$zMax = 2.40
+  [double]$kSpeed = 0.012,
+  [int]$LeadFrames = 6,
+  [double]$zMin = 1.25,
+  [double]$zMax = 3.0,
+  [double]$zBias = 0.25
 )
 
 Write-Host "Options: SkipMissingVars=$($SkipMissingVars.IsPresent)  DefaultIfMissing=$($DefaultIfMissing.IsPresent)"
@@ -150,7 +151,8 @@ Get-ChildItem $inDir -File -Filter "*.mp4" | ForEach-Object {
   $cyAgg = "($cyN)+($LeadFrames)*($cypN)"
 
   $speed = "sqrt(($cxpN)*($cxpN)+($cypN)*($cypN))"
-  $zAgg  = "min(max((($zN)+($kSpeed)*($speed)),$zMin),$zMax)"
+  $zBase = "(min(max(($zN),$zMin),$zMax))"
+  $zAgg  = "min(max((($zBase)+($zBias))-($kSpeed)*($speed),$zMin),$zMax)"
 
   $w = "floor(((ih*9/16)/($zAgg))/2)*2"
   $h = "floor((ih/($zAgg))/2)*2"


### PR DESCRIPTION
## Summary
- raise predictive lead frame count and default zoom limits for stronger follow behavior
- add a configurable zoom bias and revised clamping to maintain higher base zoom while respecting motion-based adjustments
- update the defaults warning to avoid unicode characters that broke argument parsing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d48bfa4468832d926eb9de7df70a5b