### PR TITLE
Allow ffmpeg clip expressions and disable default fallback

### DIFF
--- a/scripts/run-compare-batch.ps1
+++ b/scripts/run-compare-batch.ps1
@@ -1,6 +1,6 @@
 param(
   [switch]$SkipMissingVars = $true,
-  [switch]$DefaultIfMissing = $true,
+  [switch]$DefaultIfMissing = $false,
   [int]$Fps = 24,
   [double]$kSpeed = 0.02,
   [int]$LeadFrames = 6,
@@ -175,7 +175,6 @@ Get-ChildItem $inDir -File -Filter "*.mp4" | ForEach-Object {
   Write-Host ">> filter: $filter"
 
   # run ffmpeg (inline filter avoids the script-file quoting mess)
-  if ($filter -match 'clip\(') { throw 'clip() still present after expansion' }
   & $ffmpeg -hide_banner -y -nostdin `
     -i $inPath `
     -filter_complex $filter `


### PR DESCRIPTION
## Summary
- stop throwing when ffmpeg clip() remains in the filter so valid expressions can run
- default the batch runner to skip fallback framing instead of silently center cropping

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4a5957dfc832d82499df6d09990bc