### PR TITLE
Fix normalization conditional in Generate-Missing-Vars

### DIFF
--- a/scripts/Generate-Missing-Vars.ps1
+++ b/scripts/Generate-Missing-Vars.ps1
@@ -245,7 +245,7 @@ foreach ($target in $Targets) {
 
   # If the strict check fails, try to normalize once
   if (-not (Test-VarsFile -Path $varsPath)) {
-    if (Normalize-VarsFile -Path $varsPath -and (Test-VarsFile -Path $varsPath)) {
+    if ( (Normalize-VarsFile -Path $varsPath) -and (Test-VarsFile -Path $varsPath) ) {
       Write-Host "Normalized vars format for $target" -ForegroundColor Yellow
     }
     else {


### PR DESCRIPTION
## Summary
- ensure the normalization conditional wraps each command invocation in parentheses for clarity and correctness

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d539723518832dacd368284e723b2a