### PR TITLE
Add deadband XY to missing vars autoframe batch

### DIFF
--- a/scripts/Generate-Missing-Vars.ps1
+++ b/scripts/Generate-Missing-Vars.ps1
@@ -212,7 +212,16 @@ foreach ($target in $Targets) {
       Invoke-ExternalCommand -FilePath $psGenerator.FullName -Arguments $args -DisplayName $psGenerator.FullName
     }
     'PythonPipeline' {
-      $trackerArgs = @($pythonTracker.FullName, '--in', $inputPath, '--csv', $csvPath, '--profile', 'portrait', '--roi', 'goal', '--goal_side', 'auto')
+      $deadbandXY = '0.06,0.04'
+      $trackerArgs = @(
+        $pythonTracker.FullName,
+        '--in', $inputPath,
+        '--csv', $csvPath,
+        '--profile', 'portrait',
+        '--roi', 'goal',
+        '--goal_side', 'auto',
+        '--deadband_xy', $deadbandXY
+      )
       Invoke-ExternalCommand -FilePath $pythonExe -Arguments $trackerArgs -DisplayName "$pythonExe $([IO.Path]::GetFileName($pythonTracker.FullName))"
 
       if (-not (Test-Path -LiteralPath $csvPath)) {


### PR DESCRIPTION
## Summary
- ensure the Generate-Missing-Vars batch script passes a deadband_xy argument when invoking autoframe
- add a reusable 0.06,0.04 deadband string to the tracker arguments in Python pipeline mode

## Testing
- not run (PowerShell script change only)


------
https://chatgpt.com/codex/tasks/task_e_68d566c1c508832d8981827d4c308a78