### PR TITLE
Handle null refs in cleanup script

### DIFF
--- a/tools/cleanup/Clean-SoccerVideo.ps1
+++ b/tools/cleanup/Clean-SoccerVideo.ps1
@@ -186,7 +186,11 @@ function Find-Unreferenced {
   $unref = @()
 
   # Use array membership to avoid Contains() weirdness in some PS environments
-  $refArr = $Refs.ToArray()
+  # Robust conversion to a string[] even if $Refs is null or (accidentally) a string
+  [string[]]$refArr = @()
+  if ($null -ne $Refs -and $Refs -isnot [string]) {
+    $refArr = @($Refs | ForEach-Object { $_ })
+  }
 
   foreach ($f in $Files) {
     $rel = $f.FullName.Replace($rootFull,'').TrimStart('\','/')


### PR DESCRIPTION
## Summary
- guard conversion of the references hash set to an array in Find-Unreferenced
- ensure null or string values do not cause conversion errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d58ca111d0832d9dca129e3c23f574