### PR TITLE
Adjust landscape goal vertical guardrails

### DIFF
--- a/configs/zoom.yaml
+++ b/configs/zoom.yaml
@@ -39,11 +39,23 @@ profiles:
   landscape:
     aspect_ratio: 1.7777777778  # 16:9 width:height
     fallback_bias_y: 0.5
+    goal:
+      v_enabled: true
+      v_top_margin: 60
+      v_bottom_margin: 60
+      v_deadzone: 8
+      v_gain: 0.70
+      goal_bias: 0.30
+      conf_th: 0.35
+      snap_hold_ms: 160
     v_enabled: true
-    v_gain: 0.85
-    v_deadzone: 6.0
-    v_top_margin: 40
-    v_bottom_margin: 40
+    v_gain: 0.70
+    v_deadzone: 8.0
+    v_top_margin: 60
+    v_bottom_margin: 60
+    goal_bias: 0.30
+    conf_th: 0.35
+    snap_hold_ms: 160
     zoom:
       min: 1.0
       max: 1.9


### PR DESCRIPTION
## Summary
- add goal-specific vertical guardrail settings to the landscape profile
- raise top/bottom margins, increase deadzone, and reduce gain for smoother vertical steering
- expose goal bias, confidence, and snap hold defaults for the landscape profile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5a84450fc832d840050c529a6d08d