### PR TITLE
Add corridor clamps and ffmpeg wrapper for autoframe

### DIFF
--- a/scripts/apply_zooms.ps1
+++ b/scripts/apply_zooms.ps1
@@ -1,0 +1,53 @@
+param(
+    [Parameter(Mandatory=$true)][string]$In,
+    [Parameter(Mandatory=$true)][string]$Out,
+    [Parameter(Mandatory=$true)][Alias('Vars')][string]$Vars,
+    [Parameter(Mandatory=$true)][int]$Fps,
+    [double]$GoalLeft,
+    [double]$GoalRight,
+    [double]$PadPx,
+    [double]$StartRampSec,
+    [double]$TGoalSec,
+    [double]$CeleSec,
+    [double]$CeleTight,
+    [double]$YMin,
+    [double]$YMax,
+    [switch]$ScaleFirst
+)
+
+$ErrorActionPreference = 'Stop'
+
+Import-Module "$PSScriptRoot\..\tools\Autoframe.psm1" -Force
+
+$vfArgs = @{
+    VarsPath = $Vars
+    fps = $Fps
+}
+
+if ($PSBoundParameters.ContainsKey('GoalLeft')) { $vfArgs.goalLeft = $GoalLeft }
+if ($PSBoundParameters.ContainsKey('GoalRight')) { $vfArgs.goalRight = $GoalRight }
+if ($PSBoundParameters.ContainsKey('PadPx')) { $vfArgs.padPx = $PadPx }
+if ($PSBoundParameters.ContainsKey('StartRampSec')) { $vfArgs.startRampSec = $StartRampSec }
+if ($PSBoundParameters.ContainsKey('TGoalSec')) { $vfArgs.tGoalSec = $TGoalSec }
+if ($PSBoundParameters.ContainsKey('CeleSec')) { $vfArgs.celeSec = $CeleSec }
+if ($PSBoundParameters.ContainsKey('CeleTight')) { $vfArgs.celeTight = $CeleTight }
+if ($PSBoundParameters.ContainsKey('YMin')) { $vfArgs.yMin = $YMin }
+if ($PSBoundParameters.ContainsKey('YMax')) { $vfArgs.yMax = $YMax }
+if ($ScaleFirst.IsPresent) { $vfArgs.ScaleFirst = $true }
+
+$vf = New-VFChain @vfArgs
+
+$ffmpegArgs = @(
+    '-y',
+    '-i', $In,
+    '-vf', $vf,
+    '-c:v', 'libx264',
+    '-crf', '19',
+    '-preset', 'veryfast',
+    $Out
+)
+
+& ffmpeg @ffmpegArgs
+if ($LASTEXITCODE -ne 0) {
+    throw "ffmpeg failed with exit code $LASTEXITCODE"
+}


### PR DESCRIPTION
## Summary
- add corridor, y-band, and celebration lock controls to the autoframe CLI and runtime
- update the Autoframe PowerShell module to build filter chains from the new optional parameters
- add an apply_zooms.ps1 helper that loads the module and runs ffmpeg with the generated chain

## Testing
- python -m compileall autoframe.py

------
https://chatgpt.com/codex/tasks/task_e_68d6879cc144832d8c7e9d007c77806f