### PR TITLE
Refine autoframe module and tooling

### DIFF
--- a/pipeline/apply_zooms.ps1
+++ b/pipeline/apply_zooms.ps1
@@ -46,4 +46,11 @@ $vf = New-VFChain `
     -yMax $YMax `
     -ScaleFirst:$ScaleFirst
 
-ffmpeg -y -i $In -vf $vf -c:v libx264 -crf 19 -preset veryfast $Out
+if ([string]::IsNullOrWhiteSpace($Out)) {
+    throw 'Output path cannot be empty.'
+}
+
+& ffmpeg -y -i $In -vf $vf -c:v libx264 -crf 19 -preset veryfast $Out
+if ($LASTEXITCODE -ne 0) {
+    throw "ffmpeg failed with exit code $LASTEXITCODE"
+}

--- a/scripts/apply_zooms.ps1
+++ b/scripts/apply_zooms.ps1
@@ -37,6 +37,10 @@ if ($ScaleFirst.IsPresent) { $vfArgs.ScaleFirst = $true }
 
 $vf = New-VFChain @vfArgs
 
+if ([string]::IsNullOrWhiteSpace($Out)) {
+    throw 'Output path cannot be empty.'
+}
+
 $ffmpegArgs = @(
     '-y',
     '-i', $In,

--- a/scripts/quick_test_goal_clip.ps1
+++ b/scripts/quick_test_goal_clip.ps1
@@ -30,5 +30,12 @@ $vf = New-VFChain `
     -yMax $YMax `
     -ScaleFirst:$ScaleFirst
 
+if ([string]::IsNullOrWhiteSpace($Out)) {
+    throw 'Output path cannot be empty.'
+}
+
 Write-Host "VF: $vf"
-ffmpeg -y -i $In -vf $vf -c:v libx264 -crf 19 -preset veryfast $Out
+& ffmpeg -y -i $In -vf $vf -c:v libx264 -crf 19 -preset veryfast $Out
+if ($LASTEXITCODE -ne 0) {
+    throw "ffmpeg failed with exit code $LASTEXITCODE"
+}

--- a/scripts/refit_goal_clip.ps1
+++ b/scripts/refit_goal_clip.ps1
@@ -98,4 +98,11 @@ $vf = New-VFChain `
     -yMax $YMax `
     -ScaleFirst:$ScaleFirst
 
-ffmpeg -y -i $In -vf $vf -c:v libx264 -crf 19 -preset veryfast $Out
+if ([string]::IsNullOrWhiteSpace($Out)) {
+    throw 'Output path cannot be empty.'
+}
+
+& ffmpeg -y -i $In -vf $vf -c:v libx264 -crf 19 -preset veryfast $Out
+if ($LASTEXITCODE -ne 0) {
+    throw "ffmpeg failed with exit code $LASTEXITCODE"
+}


### PR DESCRIPTION
## Summary
- harden the Autoframe PowerShell helpers by stripping clip() calls before clamping zoom and returning clean even-dimension window math
- extend autoframe.py with quick polynomial export support and a --poly_out flag for writing ps1vars directly
- route the ffmpeg helper scripts through New-VFChain with consistent module imports, output guards, and ScaleFirst handling while rebuilding the comparison workflow around the shared filter chain

## Testing
- python -m compileall autoframe.py fit_expr.py


------
https://chatgpt.com/codex/tasks/task_e_68d68a0079c8832d8d8f91f1d45ce8b7