### PR TITLE
Keep autoframe timing expressions n-based

### DIFF
--- a/tools/Autoframe.psm1
+++ b/tools/Autoframe.psm1
@@ -1,21 +1,11 @@
 function Convert-ToFrameExpr {
-    param(
-        [string]$poly,
-        [int]$fps
-    )
-
-    if ([string]::IsNullOrWhiteSpace($poly)) {
-        return $poly
-    }
-
-    $pattern = '(?<![A-Za-z0-9_])n(?![A-Za-z0-9_])'
-    return [System.Text.RegularExpressions.Regex]::Replace($poly, $pattern, "(t*$fps)")
+    param([Parameter(Mandatory)][string]$poly, [Parameter(Mandatory)][int]$fps)
+    # DO NOT swap n -> (t*fps). Keep 'n' so crop eval doesn't see 't' at init.
+    return $poly
 }
 
 function Remove-ClipCalls {
     param([Parameter(Mandatory)][string]$expr)
-    # strip clip(<anything_without_commas_in_top_level>, lo, hi) -> <that_first_arg>
-    # since we control the poly formatting (no commas), this is safe.
     $res = $expr
     while ($res -match 'clip\(\s*([^,]+?)\s*,\s*[-+0-9.eE]+\s*,\s*[-+0-9.eE]+\s*\)') {
         $res = $res -replace 'clip\(\s*([^,]+?)\s*,\s*[-+0-9.eE]+\s*,\s*[-+0-9.eE]+\s*\)', '$1'
@@ -24,28 +14,17 @@ function Remove-ClipCalls {
 }
 
 function Get-SafeZoomExpr {
-    param(
-        [string]$zExpr,
-        [int]$fps,
-        [double]$minZ = 1.08,
-        [double]$maxZ = 2.40
-    )
-
-    $clean = Remove-ClipCalls -expr $zExpr
-    $inner = Convert-ToFrameExpr -poly $clean -fps $fps
-
-    if ([string]::IsNullOrWhiteSpace($inner)) {
-        $inner = "1.0"
-    }
-
+    param([Parameter(Mandatory)][string]$zExpr,
+          [Parameter(Mandatory)][int]$fps,
+          [double]$minZ = 1.08,
+          [double]$maxZ = 2.40)
+    # Leave n-based poly alone; just strip clip() and clamp via if()
+    $inner = Remove-ClipCalls -expr (Convert-ToFrameExpr -poly $zExpr -fps $fps)
     return "if(lte(($inner),$minZ),$minZ, if(gte(($inner),$maxZ),$maxZ, ($inner)))"
 }
 
 function Get-EvenWindowExprs {
-    param(
-        [string]$zz
-    )
-
+    param([Parameter(Mandatory)][string]$zz)
     $w = "max(16, floor(((ih*9/16)/($zz))/2)*2)"
     $h = "max(16, floor((ih/($zz))/2)*2)"
     return @{
@@ -56,126 +35,83 @@ function Get-EvenWindowExprs {
 
 function Build-GoalCorridorChain {
     param(
-        [string]$cxExpr,
-        [string]$cyExpr,
-        [string]$zExpr,
+        [Parameter(Mandatory)][string]$cxExpr,
+        [Parameter(Mandatory)][string]$cyExpr,
+        [Parameter(Mandatory)][string]$zExpr,
         [int]$fps = 24,
-        [double]$goalLeft,
-        [double]$goalRight,
-        [double]$padPx = 40,
-        [double]$startRampSec = 0.0,
-        [double]$tGoalSec,
-        [double]$celeSec,
-        [double]$celeTight,
-        [double]$yMin,
-        [double]$yMax,
+        [int]$goalLeft,
+        [int]$goalRight,
+        [int]$padPx = 40,
+        [double]$startRampSec = 3.0,
+        [double]$tGoalSec = 10.0,
+        [double]$celeSec = 2.0,
+        [double]$celeTight = 1.80,
+        [double]$yMin = 360,
+        [double]$yMax = 780,
         [switch]$ScaleFirst
     )
+    # Use n-based polynomials
+    $cx = Convert-ToFrameExpr -poly $cxExpr -fps $fps
+    $cy = Convert-ToFrameExpr -poly $cyExpr -fps $fps
+    $zz = Get-SafeZoomExpr   -zExpr $zExpr -fps $fps
 
-    $cxBase = Convert-ToFrameExpr -poly $cxExpr -fps $fps
-    $cyBase = Convert-ToFrameExpr -poly $cyExpr -fps $fps
-    $zzBase = Get-SafeZoomExpr -zExpr $zExpr -fps $fps
-    $win = Get-EvenWindowExprs -zz $zzBase
+    # Even window from zoom (safe for crop eval)
+    $win = Get-EvenWindowExprs -zz $zz
     $w = $win.w
     $h = $win.h
 
-    $cxCorr = $cxBase
-    if ($PSBoundParameters.ContainsKey('goalLeft') -and $PSBoundParameters.ContainsKey('goalRight')) {
-        $pad = if ($PSBoundParameters.ContainsKey('padPx')) { $padPx } else { 0 }
-        $minXc = "(($goalLeft+$pad)+($w)/2)"
-        $maxXc = "(($goalRight-$pad)-($w)/2)"
-        $cxCorr = "min(max(($cxCorr), $minXc), $maxXc)"
-        if ($startRampSec -gt 0) {
-            $ramp = "min((t/$startRampSec),1)"
-            $cxCorr = "(($cxBase)*(1-($ramp)) + ($cxCorr)*($ramp))"
-        }
-    }
+    # We'll still need "seconds" for ramps, but express seconds as n/fps (no bare 't')
+    $tExpr  = "(n/$fps)"                   # seconds from n
+    $rampR  = "min( ($tExpr/$startRampSec), 1 )"
 
-    $cyClamp = $cyBase
-    if ($PSBoundParameters.ContainsKey('yMin') -and $PSBoundParameters.ContainsKey('yMax')) {
-        $yMinC = "($yMin+($h)/2)"
-        $yMaxC = "($yMax-($h)/2)"
-        $cyClamp = "min(max(($cyClamp), $yMinC), $yMaxC)"
-    }
+    # Corridor clamp X (soft min/max based on window size)
+    $midX    = "(($goalLeft+$goalRight)/2)"
+    $minXc   = "(($goalLeft+$padPx)+($w)/2)"
+    $maxXc   = "(($goalRight-$padPx)-($w)/2)"
+    $cxSoft  = "min(max(($cx), $minXc), $maxXc)"
+    $cxRamp  = "( ($midX)*(1-($rampR)) + ($cxSoft)*($rampR) )"
 
-    $cxFinal = $cxCorr
-    $zzFinal = $zzBase
-    if (
-        $PSBoundParameters.ContainsKey('tGoalSec') -and
-        $PSBoundParameters.ContainsKey('celeSec') -and
-        $PSBoundParameters.ContainsKey('celeTight') -and
-        $PSBoundParameters.ContainsKey('goalLeft') -and
-        $PSBoundParameters.ContainsKey('goalRight')
-    ) {
-        $midX = "(($goalLeft+$goalRight)/2)"
-        $inCele = "between(t,$tGoalSec,($tGoalSec+$celeSec))"
-        $cxFinal = "if($inCele, $midX, $cxFinal)"
-        $zzFinal = "if($inCele, min($zzFinal,$celeTight), $zzFinal)"
-    }
+    # Celebration lock: between(t, tGoal, tGoal+cele) but t := n/fps
+    $inCele  = "between($tExpr,$tGoalSec,($tGoalSec+$celeSec))"
+    $cxFinal = "if($inCele, $midX, $cxRamp)"
+    $zzFinal = "if($inCele, min($zz,$celeTight), $zz)"   # window uses $zz (smooth), not $zzFinal
 
+    # Y band clamp (uses window height)
+    $yMinC   = "($yMin+($h)/2)"
+    $yMaxC   = "($yMax-($h)/2)"
+    $cyClamp = "min(max(($cy), $yMinC), $yMaxC)"
+
+    # center->top-left and bounds
     $x = "min(max((($cxFinal)-($w)/2),0), iw-($w))"
     $y = "min(max((($cyClamp)-($h)/2),0), ih-($h))"
 
-    if ($ScaleFirst) {
-        return "scale=w=-2:h=1080:flags=lanczos,setsar=1,crop=w='$w':h='$h':x='$x':y='$y',format=yuv420p"
-    }
-
-    return "crop=w='$w':h='$h':x='$x':y='$y',scale=w=-2:h=1080:flags=lanczos,setsar=1,format=yuv420p"
+    $chainCropScale = "crop=w='$w':h='$h':x='$x':y='$y',scale=w=-2:h=1080:flags=lanczos,setsar=1,format=yuv420p"
+    $chainScaleCrop = "scale=w=-2:h=1080:flags=lanczos,setsar=1,crop=w='$w':h='$h':x='$x':y='$y',format=yuv420p"
+    if ($ScaleFirst) { return $chainScaleCrop } else { return $chainCropScale }
 }
 
 function New-VFChain {
     param(
-        [Parameter(Mandatory=$true)][Alias('Vars')][string]$VarsPath,
+        [Parameter(Mandatory)][string]$VarsPath,
         [int]$fps = 24,
-        [double]$goalLeft,
-        [double]$goalRight,
-        [double]$padPx,
-        [double]$startRampSec,
-        [double]$tGoalSec,
-        [double]$celeSec,
-        [double]$celeTight,
-        [double]$yMin,
-        [double]$yMax,
+        [int]$goalLeft,
+        [int]$goalRight,
+        [int]$padPx = 40,
+        [double]$startRampSec = 3.0,
+        [double]$tGoalSec = 10.0,
+        [double]$celeSec = 2.0,
+        [double]$celeTight = 1.80,
+        [double]$yMin = 360,
+        [double]$yMax = 780,
         [switch]$ScaleFirst
     )
-
-    if (-not (Test-Path $VarsPath)) {
-        throw "Vars file not found: $VarsPath"
-    }
-
+    if (-not (Test-Path $VarsPath)) { throw "Vars file not found: $VarsPath" }
     . $VarsPath
-
-    if (-not (Test-Path variable:cxExpr)) {
-        throw "Expected `$cxExpr to be defined in vars file."
-    }
-
-    if (-not (Test-Path variable:cyExpr)) {
-        throw "Expected `$cyExpr to be defined in vars file."
-    }
-
-    if (-not (Test-Path variable:zExpr)) {
-        throw "Expected `$zExpr to be defined in vars file."
-    }
-
-    $callArgs = @{
-        cxExpr = $cxExpr
-        cyExpr = $cyExpr
-        zExpr = $zExpr
-        fps = $fps
-    }
-
-    if ($PSBoundParameters.ContainsKey('goalLeft')) { $callArgs.goalLeft = $goalLeft }
-    if ($PSBoundParameters.ContainsKey('goalRight')) { $callArgs.goalRight = $goalRight }
-    if ($PSBoundParameters.ContainsKey('padPx')) { $callArgs.padPx = $padPx }
-    if ($PSBoundParameters.ContainsKey('startRampSec')) { $callArgs.startRampSec = $startRampSec }
-    if ($PSBoundParameters.ContainsKey('tGoalSec')) { $callArgs.tGoalSec = $tGoalSec }
-    if ($PSBoundParameters.ContainsKey('celeSec')) { $callArgs.celeSec = $celeSec }
-    if ($PSBoundParameters.ContainsKey('celeTight')) { $callArgs.celeTight = $celeTight }
-    if ($PSBoundParameters.ContainsKey('yMin')) { $callArgs.yMin = $yMin }
-    if ($PSBoundParameters.ContainsKey('yMax')) { $callArgs.yMax = $yMax }
-    if ($ScaleFirst.IsPresent) { $callArgs.ScaleFirst = $true }
-
-    return Build-GoalCorridorChain @callArgs
+    if (-not ($cxExpr -and $cyExpr -and $zExpr)) { throw "Expected cxExpr, cyExpr, zExpr in $VarsPath" }
+    return (Build-GoalCorridorChain -cxExpr $cxExpr -cyExpr $cyExpr -zExpr $zExpr -fps $fps `
+        -goalLeft $goalLeft -goalRight $goalRight -padPx $padPx -startRampSec $startRampSec `
+        -tGoalSec $tGoalSec -celeSec $celeSec -celeTight $celeTight -yMin $yMin -yMax $yMax `
+        -ScaleFirst:$ScaleFirst)
 }
 
 Export-ModuleMember -Function Convert-ToFrameExpr,Remove-ClipCalls,Get-SafeZoomExpr,Get-EvenWindowExprs,Build-GoalCorridorChain,New-VFChain


### PR DESCRIPTION
## Summary
- keep polynomial expressions n-based to avoid introducing t in crop expressions
- add helper adjustments for safe zoom clamping, window sizing, and celebration timing based on n/fps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6a4283158832d8a092834494a11ca