### PR TITLE
Prefer motion portrait vars and widen fitter tuning

### DIFF
--- a/scripts/Generate-Missing-Vars.ps1
+++ b/scripts/Generate-Missing-Vars.ps1
@@ -228,7 +228,21 @@ foreach ($target in $Targets) {
         throw "Tracker did not produce CSV: $csvPath"
       }
 
-      $fitterArgs = @($pythonFitter.FullName, '--csv', $csvPath, '--out', $varsPath, '--profile', 'portrait')
+      $fitterArgs = @(
+        $pythonFitter.FullName,
+        '--csv', $csvPath,
+        '--out', $varsPath,
+        '--profile', 'portrait',
+        '--roi', 'goal',
+        '--degree', '3',
+        '--lead-ms', '12',
+        '--alpha-slow', '0.06',
+        '--alpha-fast', '0.60',
+        '--z-wide', '1.02',
+        '--z-tight', '1.60',
+        '--zoom-tighten-rate', '0.010',
+        '--zoom-widen-rate', '0.200'
+      )
       Invoke-ExternalCommand -FilePath $pythonExe -Arguments $fitterArgs -DisplayName "$pythonExe $([IO.Path]::GetFileName($pythonFitter.FullName))"
     }
     default {

--- a/scripts/run-compare-batch.ps1
+++ b/scripts/run-compare-batch.ps1
@@ -111,8 +111,24 @@ Get-ChildItem $inDir -File -Filter "*.mp4" | ForEach-Object {
 
   # map:  "...\X__NAME__tA-tB.mp4"  ->  "...\X__NAME__tA-tB_zoom.ps1vars"
   $stem     = [IO.Path]::GetFileNameWithoutExtension($_.Name)
-  $varsPath = Join-Path $varsDir ($stem + "_zoom.ps1vars")
-  $vars = Load-ZoomVars $varsPath
+  $varsPath = $null
+  $vars = $null
+  $candidatePaths = @(
+    Join-Path $varsDir ($stem + "_motion.ps1vars"),
+    Join-Path $varsDir ($stem + "_zoom.ps1vars")
+  )
+  foreach ($candidate in $candidatePaths) {
+    if (-not $candidate) { continue }
+    $loaded = Load-ZoomVars $candidate
+    if ($null -ne $loaded) {
+      $varsPath = $candidate
+      $vars = $loaded
+      break
+    }
+  }
+  if (-not $varsPath) {
+    $varsPath = $candidatePaths[-1]
+  }
   $name = $_.Name
   if ($null -eq $vars) {
     if ($DefaultIfMissing) {


### PR DESCRIPTION
## Summary
- prefer motion-based portrait .ps1vars when building compare renders, falling back to the legacy zoom variants
- widen the portrait refit produced by Generate-Missing-Vars.ps1 by passing portrait-friendly tuning into fit_expr.py

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6ae71c6b8832da239981479e02f73