### PR TITLE
Add phase-aware framing parameters to goal corridor

### DIFF
--- a/tools/Autoframe.psm1
+++ b/tools/Autoframe.psm1
@@ -48,6 +48,15 @@ function Build-GoalCorridorChain {
         [double]$celeTight = 1.80,
         [double]$yMin = 360,
         [double]$yMax = 780,
+        [double]$PreWideSec = 2.0,
+        [int]$EarlyLeft = 720,
+        [int]$EarlyRight = 1200,
+        [int]$EarlyPadPx = 24,
+        [double]$ShotLead = 0.6,
+        [double]$ShotTrail = 0.9,
+        [double]$ShotZoomCap = 1.15,
+        [double]$CeleBlend = 0.6,
+        [double]$CeleZoomCap = 1.22,
         [switch]$ScaleFirst
     )
     # Use n-based polynomials
@@ -55,34 +64,68 @@ function Build-GoalCorridorChain {
     $cy = Convert-ToFrameExpr -poly $cyExpr -fps $fps
     $zz = Get-SafeZoomExpr   -zExpr $zExpr -fps $fps
 
-    # Even window from zoom (safe for crop eval)
-    $win = Get-EvenWindowExprs -zz $zz
-    $w = $win.w
-    $h = $win.h
+    # time helpers
+    $t      = "(n/$fps)"
+    $inPre  = "between($t,0,$PreWideSec)"
+    $inShot = "between($t,($tGoalSec-$ShotLead),($tGoalSec+$ShotTrail))"
+    $inCele = "between($t,$tGoalSec,($tGoalSec+$celeSec))"
 
-    # We'll still need "seconds" for ramps, but express seconds as n/fps (no bare 't')
-    $tExpr  = "(n/$fps)"                   # seconds from n
-    $rampR  = "min( ($tExpr/$startRampSec), 1 )"
+    # goal & window centers
+    $midX = "(($goalLeft+$goalRight)/2)"
 
-    # Corridor clamp X (soft min/max based on window size)
-    $midX    = "(($goalLeft+$goalRight)/2)"
-    $minXc   = "(($goalLeft+$padPx)+($w)/2)"
-    $maxXc   = "(($goalRight-$padPx)-($w)/2)"
-    $cxSoft  = "min(max(($cx), $minXc), $maxXc)"
-    $cxRamp  = "( ($midX)*(1-($rampR)) + ($cxSoft)*($rampR) )"
+    # base zoom poly (already converted n->t*fps upstream)
+    # $zz is your cleaned/clamped zoom expression
+    # For width/height we’ll phase-cap zoom:
+    $zPre  = $zz
+    $zShot = "min($zz,$ShotZoomCap)"
+    $celeWidthCap = "min($CeleZoomCap,$celeTight)"
+    $zCele = "min($zz,$celeWidthCap)"
 
-    # Celebration lock: between(t, tGoal, tGoal+cele) but t := n/fps
-    $inCele  = "between($tExpr,$tGoalSec,($tGoalSec+$celeSec))"
-    $cxFinal = "if($inCele, $midX, $cxRamp)"
-    $zzFinal = "if($inCele, min($zz,$celeTight), $zz)"   # window uses $zz (smooth), not $zzFinal
+    # even crop window using phase-zoom
+    $wPre  = "max(16, floor(((ih*9/16)/($zPre))/2)*2)"
+    $hPre  = "max(16, floor((ih/($zPre))/2)*2)"
+    $wShot = "max(16, floor(((ih*9/16)/($zShot))/2)*2)"
+    $hShot = "max(16, floor((ih/($zShot))/2)*2)"
+    $wCele = "max(16, floor(((ih*9/16)/($zCele))/2)*2)"
+    $hCele = "max(16, floor((ih/($zCele))/2)*2)"
 
-    # Y band clamp (uses window height)
-    $yMinC   = "($yMin+($h)/2)"
-    $yMaxC   = "($yMax-($h)/2)"
+    # pick w/h by phase
+    $w = "if($inShot,$wShot, if($inCele,$wCele,$wPre))"
+    $h = "if($inShot,$hShot, if($inCele,$hCele,$hPre))"
+
+    # corridor clamps (early is wider & looser)
+    $minXcEarly = "(($EarlyLeft+$EarlyPadPx)+($w)/2)"
+    $maxXcEarly = "(($EarlyRight-$EarlyPadPx)-($w)/2)"
+    $minXcGoal  = "(($goalLeft+$padPx)+($w)/2)"
+    $maxXcGoal  = "(($goalRight-$padPx)-($w)/2)"
+
+    # base track in time (already built as $cx, $cy using n->t*fps)
+    $cxEarly = "min(max(($cx), $minXcEarly), $maxXcEarly)"
+    $cxGoal  = "min(max(($cx), $minXcGoal),  $maxXcGoal)"
+
+    # start ramp (smoothly move from midX to the clamped track)
+    $r = "min(($t/$startRampSec),1)"
+    $cxRampEarly = "( ($midX)*(1-($r)) + ($cxEarly)*($r) )"
+    $cxRampGoal  = "( ($midX)*(1-($r)) + ($cxGoal)*($r) )"
+
+    # shot: center the goal so we see frame+net
+    $cxShot = $midX
+
+    # celebration: blend between tracker and goal centre to follow scorer but keep goal visible
+    $cxCeleFollow = "( ($cxGoal)*$CeleBlend + ($midX)*(1-$CeleBlend) )"
+
+    # phase X centre
+    $cxPhase = "if($inShot,$cxShot, if($inCele,$cxCeleFollow, $cxRampEarly))"
+    # After PreWideSec expires, switch ramp source to goal corridor
+    $cxPhase = "if(gt($t,$PreWideSec), if($inShot,$cxShot, if($inCele,$cxCeleFollow, $cxRampGoal)), $cxPhase)"
+
+    # Y clamp (same band; you can loosen a little during shot)
+    $yMinC   = "($yMin+24+($h)/2)"
+    $yMaxC   = "($yMax-24-($h)/2)"
     $cyClamp = "min(max(($cy), $yMinC), $yMaxC)"
 
-    # center->top-left and bounds
-    $x = "min(max((($cxFinal)-($w)/2),0), iw-($w))"
+    # convert centre->top-left and stay in-bounds
+    $x = "min(max((($cxPhase)-($w)/2),0), iw-($w))"
     $y = "min(max((($cyClamp)-($h)/2),0), ih-($h))"
 
     $chainCropScale = "crop=w='$w':h='$h':x='$x':y='$y',scale=w=-2:h=1080:flags=lanczos,setsar=1,format=yuv420p"
@@ -103,6 +146,15 @@ function New-VFChain {
         [double]$celeTight = 1.80,
         [double]$yMin = 360,
         [double]$yMax = 780,
+        [double]$PreWideSec = 2.0,
+        [int]$EarlyLeft = 720,
+        [int]$EarlyRight = 1200,
+        [int]$EarlyPadPx = 24,
+        [double]$ShotLead = 0.6,
+        [double]$ShotTrail = 0.9,
+        [double]$ShotZoomCap = 1.15,
+        [double]$CeleBlend = 0.6,
+        [double]$CeleZoomCap = 1.22,
         [switch]$ScaleFirst
     )
     if (-not (Test-Path $VarsPath)) { throw "Vars file not found: $VarsPath" }
@@ -111,6 +163,9 @@ function New-VFChain {
     return (Build-GoalCorridorChain -cxExpr $cxExpr -cyExpr $cyExpr -zExpr $zExpr -fps $fps `
         -goalLeft $goalLeft -goalRight $goalRight -padPx $padPx -startRampSec $startRampSec `
         -tGoalSec $tGoalSec -celeSec $celeSec -celeTight $celeTight -yMin $yMin -yMax $yMax `
+        -PreWideSec $PreWideSec -EarlyLeft $EarlyLeft -EarlyRight $EarlyRight -EarlyPadPx $EarlyPadPx `
+        -ShotLead $ShotLead -ShotTrail $ShotTrail -ShotZoomCap $ShotZoomCap -CeleBlend $CeleBlend `
+        -CeleZoomCap $CeleZoomCap `
         -ScaleFirst:$ScaleFirst)
 }
 


### PR DESCRIPTION
## Summary
- add new corridor and zoom parameters to `New-VFChain` so callers can tune early, shot, and celebration behaviour
- implement phase-aware width, clamping, and centering logic in `Build-GoalCorridorChain` to honor the new parameters

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6b1aa2730832d804f171c1acf6f2e