### PR TITLE
Improve action director CSV parsing tolerance

### DIFF
--- a/action_director.py
+++ b/action_director.py
@@ -286,7 +286,13 @@ def main() -> None:
     parser.add_argument("--out_ffmpeg", required=True)
     args = parser.parse_args()
 
-    df = pd.read_csv(args.csv)
+    df = pd.read_csv(
+        args.csv,
+        comment="#",
+        sep=None,
+        engine="python",
+        on_bad_lines="skip",
+    )
     df = derive_vel(df, args.fps)
 
     midx = (args.goal_left + args.goal_right) / 2.0


### PR DESCRIPTION
## Summary
- allow the action director to tolerate comments and malformed rows when loading tracking CSV files
- configure pandas to auto-detect delimiters while skipping bad lines for resilience

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6c37d53bc832dbfb8622d94fd535d