### PR TITLE
Replace track ball CLI with adaptive ROI tracking

### DIFF
--- a/track_ball_cli.py
+++ b/track_ball_cli.py
@@ -1,239 +1,190 @@
-import argparse
-import math
-import os
-
-import cv2
+#!/usr/bin/env python3
+import argparse, os, math, json
 import numpy as np
+import cv2
 from ultralytics import YOLO
 
-
-class KalmanFilter:
-    """Constant-velocity Kalman filter for (x, y, vx, vy)."""
-
-    def __init__(self, process_var_pos=6.0, process_var_vel=3.0, measurement_var=36.0):
-        self.state = None  # [x, y, vx, vy]
-        self.P = None
-        self.process_var_pos = process_var_pos
-        self.process_var_vel = process_var_vel
-        self.measurement_var = measurement_var
-
-    def is_initialized(self):
-        return self.state is not None
-
-    def initialize(self, x, y):
-        self.state = np.array([x, y, 0.0, 0.0], dtype=np.float32)
-        self.P = np.diag([400.0, 400.0, 900.0, 900.0]).astype(np.float32)
-
-    def predict(self, dt):
-        if not self.is_initialized():
-            return None
-
-        F = np.array(
-            [
-                [1.0, 0.0, dt, 0.0],
-                [0.0, 1.0, 0.0, dt],
-                [0.0, 0.0, 1.0, 0.0],
-                [0.0, 0.0, 0.0, 1.0],
-            ],
-            dtype=np.float32,
-        )
-        q_pos = self.process_var_pos * (dt ** 2)
-        q_vel = self.process_var_vel * dt
-        Q = np.diag([q_pos, q_pos, q_vel, q_vel]).astype(np.float32)
-
-        self.state = F @ self.state
-        self.P = F @ self.P @ F.T + Q
-        return self.state.copy()
-
-    def update(self, x, y):
-        if not self.is_initialized():
-            self.initialize(x, y)
-            return self.state.copy()
-
-        H = np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]], dtype=np.float32)
-        R = np.diag([self.measurement_var, self.measurement_var]).astype(np.float32)
-        z = np.array([x, y], dtype=np.float32)
-
-        residual = z - (H @ self.state)
-        S = H @ self.P @ H.T + R
-        K = self.P @ H.T @ np.linalg.inv(S)
-        self.state = self.state + K @ residual
-        I = np.eye(4, dtype=np.float32)
-        self.P = (I - K @ H) @ self.P
-        return self.state.copy()
-
-
+# ------------------------- utils -------------------------
 def hsv_orange_mask(bgr):
     hsv = cv2.cvtColor(bgr, cv2.COLOR_BGR2HSV)
+    # two orange-ish bands; tune as needed
     m1 = cv2.inRange(hsv, (5, 120, 90), (20, 255, 255))
     m2 = cv2.inRange(hsv, (0, 120, 90), (5, 255, 255))
     mask = cv2.bitwise_or(m1, m2)
     mask = cv2.medianBlur(mask, 5)
     return mask
 
+def find_orange_centroid(bgr):
+    mask = hsv_orange_mask(bgr)
+    cnts, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    best = None; best_score = 1e9
+    for c in cnts:
+        area = cv2.contourArea(c)
+        if area < 20 or area > 7000:  # tune for your footage
+            continue
+        (x,y), r = cv2.minEnclosingCircle(c)
+        if r < 2: 
+            continue
+        circ = (cv2.contourArea(c) / (math.pi*r*r + 1e-6))
+        score = abs(1.0 - circ) + 0.0001*area
+        if score < best_score:
+            best_score = score
+            best = (float(x), float(y))
+    return best
 
-def clamp_roi(x1, y1, x2, y2, width, height):
-    x1 = max(0, min(width - 1, int(round(x1))))
-    y1 = max(0, min(height - 1, int(round(y1))))
-    x2 = max(x1 + 1, min(width, int(round(x2))))
-    y2 = max(y1 + 1, min(height, int(round(y2))))
-    return x1, y1, x2, y2
+# ------------------------- Kalman (2D const-vel) -------------------------
+class Kalman2D:
+    def __init__(self, dt, q=5.0, r=8.0):
+        # state: [x, vx, y, vy]
+        self.dt = dt
+        self.x = np.zeros((4,1), dtype=np.float32)
+        self.P = np.eye(4, dtype=np.float32) * 1e3
 
+        self.F = np.array([[1, dt, 0,  0],
+                           [0,  1, 0,  0],
+                           [0,  0, 1, dt],
+                           [0,  0, 0,  1]], dtype=np.float32)
 
-def add_candidate(candidates, x, y, p, source, radius=None):
-    candidates.append({
-        "x": float(x),
-        "y": float(y),
-        "p": float(p),
-        "source": source,
-        "radius": float(radius) if radius is not None else None,
-    })
+        self.H = np.array([[1, 0, 0, 0],
+                           [0, 0, 1, 0]], dtype=np.float32)
 
+        self.Q = np.array([[dt**4/4, dt**3/2,      0,       0],
+                           [dt**3/2,    dt**2,      0,       0],
+                           [0,              0, dt**4/4, dt**3/2],
+                           [0,              0, dt**3/2,    dt**2]], dtype=np.float32) * q
 
+        self.R = np.eye(2, dtype=np.float32) * r
+
+    def init(self, px, py):
+        self.x[:] = np.array([[px],[0],[py],[0]], dtype=np.float32)
+        self.P[:] = np.eye(4, dtype=np.float32) * 5.0
+
+    def predict(self):
+        self.x = self.F @ self.x
+        self.P = self.F @ self.P @ self.F.T + self.Q
+        return float(self.x[0,0]), float(self.x[2,0])
+
+    def update(self, z):
+        z = np.array(z, dtype=np.float32).reshape(2,1)
+        y = z - (self.H @ self.x)
+        S = self.H @ self.P @ self.H.T + self.R
+        K = self.P @ self.H.T @ np.linalg.inv(S)
+        self.x = self.x + K @ y
+        I = np.eye(4, dtype=np.float32)
+        self.P = (I - K @ self.H) @ self.P
+
+# ------------------------- main -------------------------
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--inp", required=True, help="input clip")
-    parser.add_argument("--out_csv", required=True, help="output CSV path")
-    args = parser.parse_args()
-
-    model = YOLO("yolov8n.pt")  # sports ball class 32
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--inp",      required=True, help="input clip (.mp4)")
+    ap.add_argument("--out_csv",  required=True, help="output CSV path")
+    ap.add_argument("--yolo_conf", type=float, default=0.15, help="YOLO confidence")
+    ap.add_argument("--roi_pad",   type=int,   default=160,  help="base ROI pad around last position")
+    ap.add_argument("--roi_pad_max", type=int, default=480,  help="max ROI pad while missing")
+    ap.add_argument("--max_miss",  type=int,   default=36,   help="#frames allowed missing before hard reset")
+    args = ap.parse_args()
 
     cap = cv2.VideoCapture(args.inp)
+    if not cap.isOpened():
+        raise SystemExit(f"Cannot open input: {args.inp}")
     fps = cap.get(cv2.CAP_PROP_FPS) or 24.0
-    frame_w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH)) or 1920
-    frame_h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT)) or 1080
+    W   = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    H   = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+
+    model = YOLO("yolov8n.pt")
+    dt = 1.0/float(fps)
+    kf = Kalman2D(dt, q=12.0, r=9.0)
 
     rows = []
-    frame_idx = 0
-
-    kalman = KalmanFilter()
-    roi_half_min = 80.0
-    roi_half_max = max(frame_w, frame_h) / 2.0
-    roi_half = roi_half_max
+    frame = 0
+    have_init = False
     miss_count = 0
+    last_xy = None
 
     while True:
-        ok, frame_bgr = cap.read()
+        ok, bgr = cap.read()
         if not ok:
             break
+        t = frame / fps
 
-        t = frame_idx / fps
-        dt = 1.0 / fps
-        prediction = kalman.predict(dt)
-        pred_x, pred_y = (prediction[:2] if prediction is not None else (None, None))
-
-        if pred_x is not None and pred_y is not None:
-            roi_half = max(roi_half_min, min(roi_half, roi_half_max))
-            x1 = pred_x - roi_half
-            y1 = pred_y - roi_half
-            x2 = pred_x + roi_half
-            y2 = pred_y + roi_half
+        # ROI selection
+        pad = args.roi_pad if miss_count == 0 else min(args.roi_pad + miss_count*12, args.roi_pad_max)
+        if last_xy is None:
+            x1, y1, x2, y2 = 0, 0, W, H
+            roi_bgr = bgr
+            roi_off = (0,0)
         else:
-            roi_half = roi_half_max
-            x1, y1, x2, y2 = 0, 0, frame_w, frame_h
+            cx, cy = last_xy
+            x1 = max(0, int(cx - pad)); y1 = max(0, int(cy - pad))
+            x2 = min(W, int(cx + pad)); y2 = min(H, int(cy + pad))
+            roi_bgr = bgr[y1:y2, x1:x2]
+            roi_off = (x1, y1)
 
-        x1, y1, x2, y2 = clamp_roi(x1, y1, x2, y2, frame_w, frame_h)
-        roi_frame = frame_bgr[y1:y2, x1:x2]
-        roi_size = max(x2 - x1, y2 - y1)
+        det_cx, det_cy = None, None
 
-        candidates = []
-
-        # 1) YOLO detections
+        # YOLO detect in ROI (faster, more precise)
         try:
-            res = model.predict(roi_frame, verbose=False, conf=0.25, classes=[32])
+            res = model.predict(roi_bgr, verbose=False, conf=args.yolo_conf, classes=[32])
             if res and len(res[0].boxes):
                 boxes = res[0].boxes.xyxy.cpu().numpy()
                 confs = res[0].boxes.conf.cpu().numpy()
-                for (bx1, by1, bx2, by2), conf in zip(boxes, confs):
-                    cx = x1 + (bx1 + bx2) / 2.0
-                    cy = y1 + (by1 + by2) / 2.0
-                    radius = max(bx2 - bx1, by2 - by1) / 2.0
-                    add_candidate(candidates, cx, cy, conf, "yolo", radius)
+                # pick smallest likely "ball" box, bias by size & conf
+                areas = (boxes[:,2]-boxes[:,0])*(boxes[:,3]-boxes[:,1])
+                rank  = areas + (1.0-confs)*1e4  # prefer small + confident
+                i = int(np.argmin(rank))
+                x1b,y1b,x2b,y2b = boxes[i]
+                det_cx = float((x1b+x2b)/2.0) + roi_off[0]
+                det_cy = float((y1b+y2b)/2.0) + roi_off[1]
         except Exception:
             pass
 
-        # 2) HSV contour centroids
-        mask = hsv_orange_mask(roi_frame)
-        contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
-        for contour in contours:
-            area = cv2.contourArea(contour)
-            if area < 20 or area > 8000:
-                continue
-            (cx_local, cy_local), radius = cv2.minEnclosingCircle(contour)
-            if radius < 3 or radius > 60:
-                continue
-            perimeter = cv2.arcLength(contour, True)
-            circularity = 0.0 if perimeter == 0 else 4.0 * math.pi * area / (perimeter * perimeter)
-            if circularity < 0.55:
-                continue
-            confidence = 0.45 + 0.4 * min(1.0, circularity)
-            global_x = x1 + cx_local
-            global_y = y1 + cy_local
-            add_candidate(candidates, global_x, global_y, confidence, "hsv", radius)
+        # Fallback: HSV orange in ROI if YOLO missed
+        if det_cx is None:
+            c = find_orange_centroid(roi_bgr)
+            if c is not None:
+                det_cx = float(c[0]) + roi_off[0]
+                det_cy = float(c[1]) + roi_off[1]
 
-        # 3) Hough circles
-        gray = cv2.cvtColor(roi_frame, cv2.COLOR_BGR2GRAY)
-        gray = cv2.GaussianBlur(gray, (5, 5), 1.5)
-        circles = cv2.HoughCircles(
-            gray,
-            cv2.HOUGH_GRADIENT,
-            dp=1.2,
-            minDist=15,
-            param1=120,
-            param2=18,
-            minRadius=3,
-            maxRadius=60,
-        )
-        if circles is not None:
-            for cx_local, cy_local, radius in circles[0, :]:
-                global_x = x1 + cx_local
-                global_y = y1 + cy_local
-                add_candidate(candidates, global_x, global_y, 0.55, "hough", radius)
-
-        chosen = None
-        best_score = -1e9
-
-        if candidates:
-            if pred_x is None or pred_y is None:
-                chosen = max(candidates, key=lambda c: c["p"])
+        # Kalman + bookkeeping
+        if det_cx is not None and det_cy is not None:
+            if not have_init:
+                kf.init(det_cx, det_cy)
+                have_init = True
             else:
-                gate_distance = max(90.0, 0.25 * roi_size)
-                lam = 1.0 / max(gate_distance, 1.0)
-                for cand in candidates:
-                    dist = math.hypot(cand["x"] - pred_x, cand["y"] - pred_y)
-                    if dist > gate_distance:
-                        continue
-                    score = cand["p"] - lam * dist
-                    if score > best_score:
-                        best_score = score
-                        chosen = cand
-
-        if chosen is not None:
-            kalman.update(chosen["x"], chosen["y"])
+                kf.predict()
+                kf.update((det_cx, det_cy))
+            est_x, est_y = det_cx, det_cy
+            last_xy = (est_x, est_y)
             miss_count = 0
-            roi_half = max(roi_half_min, roi_half - 8.0)
         else:
-            miss_count += 1
-            roi_half = min(roi_half + 12.0, roi_half_max)
+            # no detection: predict forward if initialized
+            if have_init:
+                est_x, est_y = kf.predict()
+                last_xy = (est_x, est_y)
+                miss_count += 1
+                if miss_count > args.max_miss:
+                    # hard reset: forget ROI for a bit
+                    have_init = False
+                    last_xy = None
+                    miss_count = 0
+            else:
+                est_x, est_y = (np.nan, np.nan)
 
-        state = kalman.state
-        if state is not None:
-            rows.append((frame_idx, t, float(state[0]), float(state[1])))
-        else:
-            rows.append((frame_idx, t, "", ""))
-
-        frame_idx += 1
+        rows.append((frame, t, est_x, est_y))
+        frame += 1
 
     cap.release()
 
-    os.makedirs(os.path.dirname(args.out_csv) or ".", exist_ok=True)
-    with open(args.out_csv, "w", newline="") as f:
-        f.write("frame,time,cx,cy\n")
-        for row in rows:
-            f.write(",".join(map(str, row)) + "\n")
-
-    print("Saved", args.out_csv)
-
+    # Save CSV with short-gap interpolation
+    os.makedirs(os.path.dirname(args.out_csv), exist_ok=True)
+    import pandas as pd
+    df = pd.DataFrame(rows, columns=["frame","time","cx","cy"])
+    for col in ["cx","cy"]:
+        s = pd.to_numeric(df[col], errors="coerce")
+        s = s.ffill(limit=10).bfill(limit=10)
+        df[col] = s
+    df.to_csv(args.out_csv, index=False)
+    print(f"Saved {args.out_csv}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- replace the ball tracking CLI with an adaptive ROI pipeline using YOLOv8n
- add HSV fallback and Kalman filtering with short-gap interpolation on export

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d89e0940d4832da84eef3a2777fa3f