### PR TITLE
Lead camera center ahead on fast passes

### DIFF
--- a/plan_render_cli.py
+++ b/plan_render_cli.py
@@ -479,8 +479,18 @@ def main():
         if ay > by:
             ay, by = 0.0, max(0.0, H - h)
 
-        left_pref = cx[i] - center_kx * w
-        top_pref = cy[i] - center_ky * h
+        cx_pref = cx[i]
+        cy_pref = cy[i]
+        if fast[i] and np.isfinite(vx[i]) and np.isfinite(vy[i]):
+            lead_t = 0.18
+            ball_ahead_x = cx[i] + vx[i] * lead_t
+            ball_ahead_y = cy[i] + vy[i] * lead_t
+            if np.isfinite(ball_ahead_x) and np.isfinite(ball_ahead_y):
+                cx_pref = 0.6 * cx[i] + 0.4 * ball_ahead_x
+                cy_pref = 0.7 * cy[i] + 0.3 * ball_ahead_y
+
+        left_pref = cx_pref - center_kx * w
+        top_pref = cy_pref - center_ky * h
 
         if i == 0:
             left[i] = clamp(left_pref, ax, bx)


### PR DESCRIPTION
## Summary
- blend the camera's preferred center ahead of the ball during fast sequences
- keep the existing player and ball constraints while nudging toward the pass target

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9b7e0e858832d8869eea71b05f0d5