### PR TITLE
Tweak Kalman filter noise for smoother ball tracking

### DIFF
--- a/track_ball_cli.py
+++ b/track_ball_cli.py
@@ -130,7 +130,7 @@ class KFState:
 
 
 class ConstantAccelerationKF:
-    def __init__(self, dt: float, accel_var: float = 3000.0) -> None:
+    def __init__(self, dt: float, accel_var: float = 3800.0) -> None:
         self.dt = float(dt)
         dt2 = self.dt * self.dt
         dt3 = dt2 * self.dt
@@ -167,7 +167,7 @@ class ConstantAccelerationKF:
         )
         Qc = np.eye(2, dtype=np.float64) * q
         self.Q = G @ Qc @ G.T
-        self.R = np.eye(2, dtype=np.float64) * 120.0
+        self.R = np.eye(2, dtype=np.float64) * 150.0
         self.x = np.zeros((6, 1), dtype=np.float64)
         self.P = np.eye(6, dtype=np.float64) * 1e4
 


### PR DESCRIPTION
## Summary
- increase the constant-acceleration model's default process noise so the tracker can follow fast shots better
- raise the measurement noise covariance to reduce jitter from noisy detections

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc03ec26d0832db2dcdbfbd0c71459