### PR TITLE
Adjust default margin and zoom limits

### DIFF
--- a/plan_render_cli.py
+++ b/plan_render_cli.py
@@ -176,9 +176,9 @@ def main() -> None:
 
     # Composition controls
     ap.add_argument("--left_frac", type=float, default=0.48)
-    ap.add_argument("--keep_margin", type=float, default=220.0)
+    ap.add_argument("--keep_margin", type=float, default=250.0)
     ap.add_argument("--zoom_min", type=float, default=1.00)
-    ap.add_argument("--zoom_max", type=float, default=1.45)
+    ap.add_argument("--zoom_max", type=float, default=1.55)
     ap.add_argument("--start_wide_s", type=float, default=1.6)
     ap.add_argument("--min_streak", type=int, default=16)
     ap.add_argument("--loss_streak", type=int, default=4)


### PR DESCRIPTION
## Summary
- increase the default keep_margin to tighten framing
- raise the default zoom_max to allow additional zoom-out headroom

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc1bd3e070832dbc85029d12af078c