### PR TITLE
Honor fixed chunk selection in smart shots pipeline

### DIFF
--- a/tools/auto_enhance/auto_enhance_smartshots.ps1
+++ b/tools/auto_enhance/auto_enhance_smartshots.ps1
@@ -373,7 +373,14 @@ function Process-File([string]$inPath,[double]$sceneThr,[double]$minShot,[int]$c
   $log   = Join-Path $dir ($base + "_ENH_SMARTSHOTS_log.csv")
 
   Write-Host "`n=== SMART SHOTS: $inPath"
-  $shots = Get-Scenes -inPath $inPath -thresh $sceneThr -minDur $minShot -cap $cap -fixedChunk $fixedChunk
+  $shots = $null
+  if ($fixedChunk -gt 0) {
+    $total = Get-DurationSec $inPath
+    $shots = Build-FixedChunks $total $fixedChunk
+  } else {
+    $shots = Get-Scenes -inPath $inPath -thresh $sceneThr -minDur $minShot -cap $cap
+  }
+
   if (-not $shots -or $shots.Count -eq 0) {
     $total = Get-DurationSec $inPath
     $shots = @([pscustomobject]@{ Start=0.0; End=$total; Dur=$total })


### PR DESCRIPTION
## Summary
- ensure smart shots `Process-File` builds fixed-duration segments when `-FixedChunk` is provided and only calls scene detection otherwise
- retain the existing whole-video fallback and shot count logging when no scenes are detected

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de9e8d3ae0832da967df46cf5c9edd