### PR TITLE
Improve track_crop MJPG writer handling

### DIFF
--- a/track_crop.py
+++ b/track_crop.py
@@ -98,31 +98,39 @@ def main() -> None:
     tracker = build_tracker(args.tracker)
     tracker.init(frame, init_rect)
 
-    fps = cap.get(cv2.CAP_PROP_FPS)
-    if not fps or fps <= 0:
+    fps = cap.get(cv2.CAP_PROP_FPS) or 0.0
+    if fps <= 0 or fps != fps:
         fps = 30.0
-    out_w, out_h = int(init_rect[2]), int(init_rect[3])
+    tracked_frame_width = int(init_rect[2])
+    tracked_frame_height = int(init_rect[3])
+    frame_size = (int(tracked_frame_width), int(tracked_frame_height))
     writer = None
     video_writer_path: Path | None = None
     if args.video_out:
-        video_path = (
-            args.video_out
-            if args.video_out.lower().endswith(".mp4")
-            else args.video_out + ".mp4"
-        )
-        video_writer_path = Path(video_path)
+        out_video_path = args.video_out
+        root, ext = os.path.splitext(out_video_path)
+        if ext.lower() not in (".avi", ".mp4", ".mkv"):
+            out_video_path = root + ".avi"
+
+        video_writer_path = Path(out_video_path)
         video_writer_path.parent.mkdir(parents=True, exist_ok=True)
-        fourcc = cv2.VideoWriter_fourcc(*"mp4v")
-        writer = cv2.VideoWriter(
-            str(video_writer_path), fourcc, fps, (out_w, out_h), isColor=True
-        )
+
+        fourcc = cv2.VideoWriter_fourcc(*"MJPG")
+        writer = cv2.VideoWriter(str(video_writer_path), fourcc, fps, frame_size)
+
         if not writer.isOpened():
-            print(f"[ERROR] Failed to open VideoWriter for: {video_writer_path}")
-            sys.exit(1)
+            fourcc = cv2.VideoWriter_fourcc(*"XVID")
+            writer = cv2.VideoWriter(str(video_writer_path), fourcc, fps, frame_size)
+
+        if not writer.isOpened():
+            raise RuntimeError(
+                f"Failed to open VideoWriter for {video_writer_path} "
+                f"(fps={fps}, size={frame_size})"
+            )
 
     frame_idx = 0
-    out_path = Path(args.out)
-    out_path.parent.mkdir(parents=True, exist_ok=True)
+    json_out_path = Path(args.out)
+    json_out_path.parent.mkdir(parents=True, exist_ok=True)
     frames_written = 0
 
     def write_crop_frame(src_frame, bbox: Tuple[float, float, float, float]) -> None:
@@ -139,7 +147,7 @@ def main() -> None:
         crop = src_frame[y0:y1, x0:x1]
         if crop.size == 0:
             return
-        crop_resized = cv2.resize(crop, (out_w, out_h), interpolation=cv2.INTER_AREA)
+        crop_resized = cv2.resize(crop, frame_size, interpolation=cv2.INTER_AREA)
         if crop_resized.dtype != "uint8":
             crop_resized = crop_resized.astype("uint8")
         writer.write(crop_resized)
@@ -159,7 +167,7 @@ def main() -> None:
         out_file.write("\n")
 
     try:
-        with out_path.open("w", encoding="utf-8") as out_file:
+        with json_out_path.open("w", encoding="utf-8") as out_file:
             emit(frame_idx, init_rect)
             write_crop_frame(frame, init_rect)
 
@@ -201,7 +209,9 @@ def main() -> None:
             )
             sys.exit(1)
         else:
-            print(f"[OK] Wrote {frames_written} frames to {output_str}")
+            print(
+                f"[track_crop] Wrote {frames_written} frames at {fps} fps -> {output_str}"
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure `track_crop.py` falls back to MJPG or XVID in an AVI container
- guard against invalid FPS values and enforce consistent frame sizing
- improve writer validation and success messaging

## Testing
- python -m compileall track_crop.py

------
https://chatgpt.com/codex/tasks/task_e_68dee0a4f6ac832d8e336540f28bc1ad