### PR TITLE
Add optional YOLO ball tracker integration

### DIFF
--- a/README_AUTOFAME.md
+++ b/README_AUTOFAME.md
@@ -53,6 +53,38 @@ Existing flags still work:
 * `--preview` writes the debug overlay (crop box, crosshair, goal anchor, IoU).
 * `--compare` writes an optional side-by-side stack of raw vs. overlayed frames.
 
+### Ball-first autoframe (optional)
+
+Pass `--ball-detector yolo --ball-weights path/to/weights.pt` to prioritise a
+trained ball detector whenever it fires. When enabled, the tracker fuses the
+smoothed YOLO center with the existing motion/goal logic so the crop follows
+the ball first, then falls back to flow-only behaviour during gaps.
+
+Additional overrides:
+
+* `--ball-min-conf` (default `0.35`) — require this confidence before trusting
+  YOLO detections.
+* `--ball-smooth-alpha` (default `0.25`) — EMA smoothing applied to the ball
+  center/box after the constant-velocity filter.
+* `--ball-max-gap` (default `12`) — reset smoothing after this many missed
+  frames.
+
+Set `--diagnostics 1` to capture the smoothed vs. raw ball detections in
+`out/autoframe_debug/ball_tracks/<clip>.csv`. Config-driven runs can toggle the
+same behaviour with the optional `ball` block in `config.yaml`:
+
+```yaml
+ball:
+  detector: yolo        # none|yolo
+  weights: models/ball_v1.pt
+  min_conf: 0.35
+  smooth_alpha: 0.25
+  max_gap: 12
+```
+
+Smart shrink, jersey bias, and downstream rendering are unchanged — they still
+operate purely on motion/optical-flow features when YOLO is disabled or misses.
+
 The CSV now contains one row per frame with columns:
 
 ```

--- a/config.yaml
+++ b/config.yaml
@@ -58,3 +58,10 @@ branding:
   profile: tsc
   default_aspect: '16x9'
   title_font: 'fonts/Montserrat-ExtraBold.ttf'
+
+ball:
+  detector: none
+  weights: models/ball_v1.pt
+  min_conf: 0.35
+  smooth_alpha: 0.25
+  max_gap: 12

--- a/soccer_highlights/ball_tracker.py
+++ b/soccer_highlights/ball_tracker.py
@@ -1,0 +1,348 @@
+"""Utilities for optional YOLO-based ball tracking."""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, List, Optional, Tuple
+
+import importlib
+import importlib.util
+
+import cv2
+import numpy as np
+
+
+def _resolve_yolo_class():
+    spec = importlib.util.find_spec("ultralytics")
+    if spec is None:
+        return None
+    module = importlib.import_module("ultralytics")
+    return getattr(module, "YOLO", None)
+
+
+YOLO_CLASS = _resolve_yolo_class()
+
+
+@dataclass
+class BallTrack:
+    """Single frame of ball tracking data."""
+
+    frame: int
+    cx: float
+    cy: float
+    width: float
+    height: float
+    conf: float
+    raw_cx: float
+    raw_cy: float
+    raw_width: float
+    raw_height: float
+    raw_conf: float
+
+    @property
+    def center(self) -> Tuple[float, float]:
+        return (self.cx, self.cy)
+
+
+class ConstantVelocityFilter:
+    """Very small helper that keeps a constant-velocity estimate."""
+
+    def __init__(self, alpha: float = 0.6) -> None:
+        self.alpha = float(np.clip(alpha, 0.0, 1.0))
+        self._position: Optional[np.ndarray] = None
+        self._velocity = np.zeros(2, dtype=np.float32)
+        self._frame_index: Optional[int] = None
+        self._last_measurement: Optional[np.ndarray] = None
+
+    def reset(self) -> None:
+        self._position = None
+        self._velocity.fill(0.0)
+        self._frame_index = None
+        self._last_measurement = None
+
+    def update(self, measurement: np.ndarray, frame_index: int) -> np.ndarray:
+        measurement = measurement.astype(np.float32)
+        if self._position is None or self._frame_index is None:
+            self._position = measurement.copy()
+            self._velocity = np.zeros_like(measurement)
+            self._frame_index = int(frame_index)
+            self._last_measurement = measurement.copy()
+            return self._position.copy()
+
+        dt = max(int(frame_index) - int(self._frame_index), 1)
+        predicted = self._position + self._velocity * dt
+        residual = measurement - predicted
+        gain = float(self.alpha)
+        self._position = predicted + gain * residual
+        if self._last_measurement is None:
+            measured_velocity = np.zeros_like(measurement)
+        else:
+            measured_velocity = (measurement - self._last_measurement) / float(dt)
+        self._velocity = (1.0 - gain) * self._velocity + gain * measured_velocity
+        self._frame_index = int(frame_index)
+        self._last_measurement = measurement.copy()
+        return self._position.copy()
+
+    def predict(self, frame_index: int) -> Optional[np.ndarray]:
+        if self._position is None or self._frame_index is None:
+            return None
+        dt = int(frame_index) - int(self._frame_index)
+        if dt <= 0:
+            return self._position.copy()
+        return self._position + self._velocity * dt
+
+
+class BallTracker:
+    """Tiny wrapper around YOLO inference with light temporal smoothing."""
+
+    def __init__(
+        self,
+        weights_path: Optional[Path],
+        min_conf: float = 0.35,
+        iou: float = 0.45,
+        device: Optional[str] = None,
+        input_size: int = 640,
+        smooth_alpha: float = 0.25,
+        max_gap: int = 12,
+    ) -> None:
+        self.weights_path = Path(weights_path) if weights_path else None
+        self.min_conf = float(np.clip(min_conf, 0.0, 1.0))
+        self.iou = float(np.clip(iou, 0.0, 1.0))
+        self.device = device
+        self.input_size = int(max(96, input_size))
+        self.smooth_alpha = float(np.clip(smooth_alpha, 0.0, 1.0))
+        self.max_gap = int(max(0, max_gap))
+        self._model = None
+        self._failed = False
+        self.failure_reason: Optional[str] = None
+        self._ball_ids: List[int] = []
+        self._velocity_filter = ConstantVelocityFilter(alpha=0.65)
+        self._ema_center: Optional[np.ndarray] = None
+        self._ema_size: Optional[np.ndarray] = None
+        self._ema_conf: Optional[float] = None
+        self._last_frame: Optional[int] = None
+
+        if YOLO_CLASS is None:
+            self._failed = True
+            self.failure_reason = "Ultralytics YOLO not available"
+        elif self.weights_path and not self.weights_path.exists():
+            self._failed = True
+            self.failure_reason = f"Ball weights not found: {self.weights_path}"
+
+    @property
+    def is_ready(self) -> bool:
+        return not self._failed
+
+    def _ensure_model(self) -> None:
+        if self._model is not None or self._failed:
+            return
+        if YOLO_CLASS is None:
+            self._failed = True
+            if self.failure_reason is None:
+                self.failure_reason = "Ultralytics YOLO not available"
+            return
+        weights = self.weights_path.as_posix() if self.weights_path else "yolov8n.pt"
+        try:
+            self._model = YOLO_CLASS(weights)
+        except Exception as exc:  # pragma: no cover - defensive guard for runtime errors
+            self._failed = True
+            self.failure_reason = f"Failed to initialise ball YOLO: {exc}"
+            self._model = None
+            return
+
+        names = getattr(self._model, "names", {}) or {}
+        if isinstance(names, dict):
+            for idx, name in names.items():
+                if isinstance(name, str) and "ball" in name.lower():
+                    self._ball_ids.append(int(idx))
+        if not self._ball_ids:
+            # Sports ball class id in COCO
+            self._ball_ids = [32]
+
+    def _reset_if_stale(self, frame_index: int) -> None:
+        if self._last_frame is None:
+            return
+        if frame_index - self._last_frame > self.max_gap:
+            self._velocity_filter.reset()
+            self._ema_center = None
+            self._ema_size = None
+            self._ema_conf = None
+
+    def _update_ema(self, value: np.ndarray, store: Optional[np.ndarray]) -> np.ndarray:
+        if store is None:
+            return value.copy()
+        alpha = float(self.smooth_alpha)
+        return alpha * value + (1.0 - alpha) * store
+
+    def update(self, frame_index: int, frame: np.ndarray) -> Optional[BallTrack]:
+        self._reset_if_stale(frame_index)
+        self._ensure_model()
+        if self._failed or self._model is None:
+            return None
+
+        height, width = frame.shape[:2]
+        params = {
+            "conf": max(0.05, min(self.min_conf, 0.99)),
+            "iou": self.iou,
+            "imgsz": self.input_size,
+            "verbose": False,
+        }
+        if self.device:
+            params["device"] = self.device
+
+        result = self._model.predict(frame, **params)
+        if not result:
+            self._register_miss(frame_index)
+            return None
+
+        boxes = getattr(result[0], "boxes", None)
+        if boxes is None:
+            self._register_miss(frame_index)
+            return None
+
+        cls = getattr(boxes, "cls", None)
+        conf = getattr(boxes, "conf", None)
+        xyxy = getattr(boxes, "xyxy", None)
+        if cls is None or conf is None or xyxy is None:
+            self._register_miss(frame_index)
+            return None
+
+        cls = cls.detach().cpu().numpy() if hasattr(cls, "detach") else np.asarray(cls)
+        conf = conf.detach().cpu().numpy() if hasattr(conf, "detach") else np.asarray(conf)
+        xyxy = xyxy.detach().cpu().numpy() if hasattr(xyxy, "detach") else np.asarray(xyxy)
+
+        best_idx = -1
+        best_conf = float("-inf")
+        best_box: Optional[np.ndarray] = None
+        for idx, (cls_id, c_score, box) in enumerate(zip(cls, conf, xyxy)):
+            if self._ball_ids and int(cls_id) not in self._ball_ids:
+                continue
+            c_val = float(c_score)
+            if c_val < self.min_conf:
+                continue
+            x1, y1, x2, y2 = box.astype(float)
+            bw = max(0.0, x2 - x1)
+            bh = max(0.0, y2 - y1)
+            if bw <= 1.0 or bh <= 1.0:
+                continue
+            if bw > width * 0.6 or bh > height * 0.6:
+                continue
+            cx = x1 + bw * 0.5
+            cy = y1 + bh * 0.5
+            if not (0.0 <= cx <= width and 0.0 <= cy <= height):
+                continue
+            if c_val > best_conf:
+                best_conf = c_val
+                best_idx = idx
+                best_box = np.array([x1, y1, x2, y2], dtype=np.float32)
+
+        if best_idx < 0 or best_box is None:
+            self._register_miss(frame_index)
+            return None
+
+        x1, y1, x2, y2 = best_box
+        bw = max(0.0, x2 - x1)
+        bh = max(0.0, y2 - y1)
+        cx = x1 + bw * 0.5
+        cy = y1 + bh * 0.5
+
+        center = np.array([cx, cy], dtype=np.float32)
+        filtered = self._velocity_filter.update(center, frame_index)
+        if self._ema_center is None:
+            self._ema_center = filtered.copy()
+        else:
+            self._ema_center = self._update_ema(filtered, self._ema_center)
+
+        size = np.array([bw, bh], dtype=np.float32)
+        if self._ema_size is None:
+            self._ema_size = size.copy()
+        else:
+            self._ema_size = self._update_ema(size, self._ema_size)
+
+        conf_val = float(best_conf)
+        if self._ema_conf is None:
+            self._ema_conf = conf_val
+        else:
+            alpha = float(self.smooth_alpha)
+            self._ema_conf = alpha * conf_val + (1.0 - alpha) * self._ema_conf
+
+        self._last_frame = int(frame_index)
+
+        return BallTrack(
+            frame=int(frame_index),
+            cx=float(self._ema_center[0]),
+            cy=float(self._ema_center[1]),
+            width=float(self._ema_size[0]),
+            height=float(self._ema_size[1]),
+            conf=float(self._ema_conf),
+            raw_cx=float(center[0]),
+            raw_cy=float(center[1]),
+            raw_width=float(size[0]),
+            raw_height=float(size[1]),
+            raw_conf=float(conf_val),
+        )
+
+    def _register_miss(self, frame_index: int) -> None:
+        if self._last_frame is None:
+            return
+        if frame_index - self._last_frame > self.max_gap:
+            self._velocity_filter.reset()
+            self._ema_center = None
+            self._ema_size = None
+            self._ema_conf = None
+
+    def track(
+        self, video_path: Path | str, out_csv: Optional[Path] = None
+    ) -> Iterator[Optional[BallTrack]]:
+        cap = cv2.VideoCapture(str(video_path))
+        if not cap.isOpened():
+            raise RuntimeError(f"Unable to open video for ball tracking: {video_path}")
+
+        writer = None
+        if out_csv is not None:
+            out_csv = Path(out_csv)
+            out_csv.parent.mkdir(parents=True, exist_ok=True)
+            csv_file = out_csv.open("w", newline="", encoding="utf-8")
+            writer = csv.writer(csv_file)
+            writer.writerow(["frame", "cx", "cy", "w", "h", "conf", "raw_cx", "raw_cy", "raw_w", "raw_h", "raw_conf"])
+        else:
+            csv_file = None
+
+        frame_idx = 0
+        try:
+            while True:
+                ok, frame = cap.read()
+                if not ok:
+                    break
+                track = self.update(frame_idx, frame)
+                if writer is not None:
+                    if track is None:
+                        writer.writerow([frame_idx, "", "", "", "", "", "", "", "", "", ""])
+                    else:
+                        writer.writerow(
+                            [
+                                track.frame,
+                                track.cx,
+                                track.cy,
+                                track.width,
+                                track.height,
+                                track.conf,
+                                track.raw_cx,
+                                track.raw_cy,
+                                track.raw_width,
+                                track.raw_height,
+                                track.raw_conf,
+                            ]
+                        )
+                yield track
+                frame_idx += 1
+        finally:
+            cap.release()
+            if csv_file is not None:
+                csv_file.close()
+
+
+__all__ = ["BallTracker", "BallTrack"]
+

--- a/soccer_highlights/config.py
+++ b/soccer_highlights/config.py
@@ -207,6 +207,25 @@ class ColorsConfig(BaseModel):
     calibrate: bool = Field(False)
 
 
+class BallConfig(BaseModel):
+    detector: str = Field("none", description="Ball detector backend (none or yolo).")
+    weights: Optional[Path] = Field(
+        Path("models/ball_v1.pt"), description="Path to YOLO weights for the ball model."
+    )
+    min_conf: float = Field(0.35, ge=0.0, le=1.0, description="Minimum confidence to trust detections.")
+    smooth_alpha: float = Field(
+        0.25, ge=0.0, le=1.0, description="EMA smoothing applied to YOLO ball tracks."
+    )
+    max_gap: int = Field(12, ge=0, description="Reset smoothing after this many missed frames.")
+
+    @validator("detector")
+    def validate_detector(cls, value: str) -> str:
+        lowered = value.lower()
+        if lowered not in {"none", "yolo"}:
+            raise ValueError("detector must be 'none' or 'yolo'")
+        return lowered
+
+
 class AppConfig(BaseModel):
     paths: PathsConfig = Field(default_factory=PathsConfig)
     detect: DetectConfig = Field(default_factory=DetectConfig)
@@ -215,6 +234,7 @@ class AppConfig(BaseModel):
     rank: RankConfig = Field(default_factory=RankConfig)
     reels: ReelConfig = Field(default_factory=ReelConfig)
     colors: ColorsConfig = Field(default_factory=ColorsConfig)
+    ball: BallConfig = Field(default_factory=BallConfig)
     profiles: Dict[str, ReelProfile] = Field(
         default_factory=lambda: {
             "broadcast": ReelProfile(name="broadcast", width=1920, height=1080, fps=30.0, crossfade_frames=6),

--- a/tests/test_ball_tracker.py
+++ b/tests/test_ball_tracker.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from soccer_highlights.ball_tracker import BallTrack
+
+
+_AUTOFRAME_SPEC = importlib.util.spec_from_file_location("autoframe", _ROOT / "autoframe.py")
+if _AUTOFRAME_SPEC is None or _AUTOFRAME_SPEC.loader is None:
+    raise ImportError("Unable to load autoframe module for tests")
+autoframe_module = importlib.util.module_from_spec(_AUTOFRAME_SPEC)
+sys.modules.setdefault("autoframe", autoframe_module)
+_AUTOFRAME_SPEC.loader.exec_module(autoframe_module)  # type: ignore[attr-defined]
+choose_target_center = getattr(autoframe_module, "choose_target_center")
+
+
+def _make_track(frame: int, center: Tuple[float, float], conf: float) -> BallTrack:
+    cx, cy = center
+    return BallTrack(
+        frame=frame,
+        cx=float(cx),
+        cy=float(cy),
+        width=14.0,
+        height=14.0,
+        conf=float(conf),
+        raw_cx=float(cx),
+        raw_cy=float(cy),
+        raw_width=14.0,
+        raw_height=14.0,
+        raw_conf=float(conf),
+    )
+
+
+def test_choose_target_center_prefers_ball_when_confident() -> None:
+    motion = (320.0, 180.0)
+    confident_ball = _make_track(0, (150.0, 90.0), 0.8)
+    fused_x, fused_y, used = choose_target_center(motion, confident_ball, 0.35)
+    assert used
+    assert fused_x == pytest.approx(confident_ball.cx)
+    assert fused_y == pytest.approx(confident_ball.cy)
+
+    faint_ball = _make_track(1, (240.0, 200.0), 0.2)
+    fused_x, fused_y, used = choose_target_center(motion, faint_ball, 0.35)
+    assert not used
+    assert fused_x == pytest.approx(motion[0])
+    assert fused_y == pytest.approx(motion[1])
+
+    seq_motion: List[Tuple[float, float]] = [(300.0, 200.0), (302.0, 203.0), (305.0, 207.0)]
+    seq_ball: List[Optional[BallTrack]] = [None, _make_track(2, (260.0, 150.0), 0.6), None]
+    fused = [choose_target_center(m, b, 0.4) for m, b in zip(seq_motion, seq_ball)]
+    assert fused[0][2] is False
+    assert fused[1][2] is True and fused[1][0] == pytest.approx(260.0)
+    assert fused[2][2] is False
+
+
+@pytest.mark.slow
+def test_fit_expr_and_ffmpeg_pipeline(tmp_path: Path) -> None:
+    if shutil.which("ffmpeg") is None:
+        pytest.skip("ffmpeg required for pipeline smoke test")
+
+    try:
+        import cv2  # type: ignore
+        import numpy as np  # type: ignore
+    except Exception:
+        pytest.skip("OpenCV and numpy required for pipeline smoke test")
+
+    width, height, fps = 640, 360, 30.0
+    frame_count = 60
+    video_path = tmp_path / "sample.mp4"
+
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(str(video_path), fourcc, fps, (width, height))
+    if not writer.isOpened():
+        pytest.skip("OpenCV build cannot open MP4 writer")
+
+    for idx in range(frame_count):
+        frame = np.zeros((height, width, 3), dtype=np.uint8)
+        cx = int(width * 0.2 + idx * 2)
+        cy = int(height * 0.5 + 20 * np.sin(idx / 5.0))
+        cv2.circle(frame, (cx, cy), 18, (0, 200, 255), -1)
+        writer.write(frame)
+    writer.release()
+
+    csv_path = tmp_path / "autoframe.csv"
+    subprocess.run(
+        [
+            sys.executable,
+            "autoframe.py",
+            "--in",
+            str(video_path),
+            "--csv",
+            str(csv_path),
+            "--profile",
+            "portrait",
+            "--ball-detector",
+            "none",
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    assert csv_path.exists()
+
+    vars_path = tmp_path / "autoframe.ps1vars"
+    subprocess.run(
+        [
+            sys.executable,
+            "fit_expr.py",
+            "--csv",
+            str(csv_path),
+            "--out",
+            str(vars_path),
+            "--profile",
+            "portrait",
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    contents = vars_path.read_text(encoding="utf-8")
+    assert "$cxExpr" in contents
+    assert "$cyExpr" in contents
+    assert "$zExpr" in contents
+
+    cropped_path = tmp_path / "cropped.mp4"
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-i",
+            str(video_path),
+            "-vf",
+            "crop=iw/1.25:ih/1.25:(iw-iw/1.25)/2:(ih-ih/1.25)/2",
+            "-frames:v",
+            str(frame_count),
+            str(cropped_path),
+        ],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    assert cropped_path.exists()
+    assert cropped_path.stat().st_size > 0


### PR DESCRIPTION
## Summary
- add a reusable soccer_highlights.ball_tracker module that smooths YOLO detections and can emit debug CSVs
- expose ball-tracking CLI toggles plus diagnostics handling in autoframe while keeping motion fallback behaviour intact
- document the new workflow, surface configuration defaults, and cover the fusion/fit pipeline with a regression test

## Testing
- pytest tests/test_ball_tracker.py

------
https://chatgpt.com/codex/tasks/task_e_68deeec470a4832d9390b6edfe7ef99f