### PR TITLE
Improve used-by filtering and orphan notes

### DIFF
--- a/tools/index_repo.py
+++ b/tools/index_repo.py
@@ -872,7 +872,11 @@ def detect_used_by(records: Sequence[FileRecord], texts: Dict[str, str]) -> None
 
     for record in records:
         used_by: Set[str] = set()
-        target_name = Path(record.repo_relpath).name.lower()
+        target_path = Path(record.repo_relpath)
+        if len(target_path.stem) <= 3:
+            record.used_by_signals = []
+            continue
+        target_name = target_path.name.lower()
         for source_path, text in texts.items():
             if target_name in text.lower() and source_path != record.repo_relpath:
                 used_by.add(source_path)
@@ -904,6 +908,7 @@ def detect_orphans(records: Sequence[FileRecord], texts: Dict[str, str]) -> List
             reasons.append("non-core category")
         if reasons and record.file_type in {"script_py", "script_ps1"}:
             record.suspect_orphan = True
+            record.notes.extend(reasons)
             orphan_rows.append(
                 {
                     "repo_relpath": record.repo_relpath,


### PR DESCRIPTION
## Summary
- skip used-by detection for files with very short basenames to reduce noise
- surface orphan-detection reasons on the record notes so SUMMARY.md shows them

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5160f02ec832d85a7d1f947c83dac