### PR TITLE
feat: add unified follow renderer and calibration tools

### DIFF
--- a/tools/README_render.md
+++ b/tools/README_render.md
@@ -1,62 +1,32 @@
-# Unified Render Follow Pipeline
+# Unified Follow Renderer
 
-The legacy `render_follow_*` scripts have been consolidated under a single,
-argument-driven workflow.  Use the PowerShell wrapper for day-to-day tasks on
-Windows, or invoke the Python CLI directly for scripting / automation.
-
-## PowerShell wrapper
+## Quick start
 
 ```powershell
-pwsh -File tools\render_follow.ps1 -In ".\out\atomic_clips\2025-09-13__TSC_vs_NEOFC\022__SHOT__t3028.10-t3059.70.mp4" -Preset Cinematic -Portrait -CleanTemp
+python tools\render_follow_unified.py --in "out/atomic_clips/2025-09-13__TSC_vs_NEOFC/022__SHOT__t3028.10-t3059.70.mp4" --preset cinematic --clean-temp
 ```
 
-* `-Preset` selects the render flavour (`Cinematic`, `Gentle`, `RealZoom`).
-* `-Portrait` enables a 1080x1920 canvas by default.  To specify a custom size
-  use `-PortraitSize "720x1280"`.
-* `-Fps`, `-Flip180`, and `-ExtraArgs` are passed through to the Python
-  implementation.
-* Add `-Legacy` to force the fallback cinematic renderer.
+## Using the PowerShell wrapper
 
-## Python CLI
-
-```bash
-python tools/render_follow_unified.py \
-  --in "./out/atomic_clips/2025-09-13__TSC_vs_NEOFC/022__SHOT__t3028.10-t3059.70.mp4" \
-  --preset realzoom \
-  --portrait 1080x1920 \
-  --fps 30 \
-  --clean-temp \
-  --labels-root "out/yolo"
+```powershell
+.\tools\render_follow.ps1 -In ".\out\atomic_clips\2025-09-13__TSC_vs_NEOFC\022__SHOT__t3028.10-t3059.70.mp4" -Preset Cinematic -Portrait
 ```
 
-Key options:
+The wrapper prints the resolved command before execution and exits with the same status code as the Python script.
 
-* `--in` / `--src`: input clip (MP4).  Both flags are accepted for compatibility.
-* `--out`: override the default `.<stem>.__<PRESET>.mp4` output name.
-* `--preset`: cinematic, gentle, or realzoom.  Presets tune camera smoothing,
-  look-ahead, and padding.
-* `--portrait`: target canvas size (`WIDTHxHEIGHT`).  Portrait mode keeps the
-  ball roughly 60% up from the bottom while clamping zoom to avoid artifacts.
-* `--labels-root`: search path for YOLO ball labels.  Multiple shards under
-  `out/yolo/*/labels/<clip_stem>_*.txt` are merged automatically.
-* `--brand-overlay` / `--endcard`: apply branding or append a 1s endcard.
-* `--clean-temp`: wipe the working folder (`out/autoframe_work/<preset>/<clip>`) before rendering.
-* `--log`: override the log location (defaults to `out/render_logs/`).
+## Calibration from tester clip
 
-## Work folders & cleanup
+```powershell
+python tools\calibrate_from_clip.py --in ".\out\atomic_clips\2025-09-13__TSC_vs_NEOFC\022__SHOT__t3028.10-t3059.70.mp4" --preset cinematic
+```
 
-* Frame caches live under `out/autoframe_work/<preset>/<clip_stem>/frames/`.
-  Re-runs reuse cached frames unless `--clean-temp` (CLI) or `-CleanTemp`
-  (PowerShell) is supplied.
-* Log files are written to `out/render_logs/` alongside a JSON summary.
-* Temporary concat manifests (`*.ffconcat`) are disposable and ignored by git.
+This performs a lightweight random search around the preset defaults and updates `tools/render_presets.yaml` when a better fit is found. A JSON summary is written to `out/render_logs/`.
 
-## Troubleshooting
+## Telemetry and debug overlay QC
 
-* **Missing labels** – The renderer falls back to a centre-biased eased camera
-  path if no YOLO detections are found.  Verify the input stem matches the label
-  file naming convention.
-* **Audio missing** – Ensure ffmpeg can read the source audio stream.  The
-  stitch step maps `-map 1:a:0?` so silent clips are handled gracefully.
-* **Cleaning caches** – Delete the folder under `out/autoframe_work/<preset>/` or
-  re-run with the clean switches mentioned above.
+```powershell
+python tools\render_follow_unified.py --in "<clip>" --preset cinematic --telemetry "out/render_logs/<stem>.jsonl"
+python tools\overlay_debug.py --in "<clip>" --telemetry "out/render_logs/<stem>.jsonl" --out "<clip>.__DEBUG.mp4"
+```
+
+Telemetry JSONL files include one record per rendered frame (with camera centres, zoom, and clamp flags). The debug overlay helper burns that information into a copy of the clip for quick QC sweeps.

--- a/tools/calibrate_from_clip.py
+++ b/tools/calibrate_from_clip.py
@@ -1,0 +1,191 @@
+"""Preset calibration helper for the unified renderer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from pathlib import Path
+from typing import Dict, List
+
+import cv2  # type: ignore
+import numpy as np
+import yaml
+
+from render_follow_unified import (
+    CameraPlanner,
+    PRESETS_PATH,
+    ensure_presets_file,
+    ffprobe_fps,
+    find_label_files,
+    interp_labels_to_fps,
+    load_labels,
+    load_presets,
+    parse_portrait,
+)
+
+
+def _video_metadata(path: Path) -> Dict[str, int]:
+    capture = cv2.VideoCapture(str(path))
+    if not capture.isOpened():
+        raise RuntimeError(f"Unable to open video {path}")
+    width = int(capture.get(cv2.CAP_PROP_FRAME_WIDTH))
+    height = int(capture.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    frame_count = int(capture.get(cv2.CAP_PROP_FRAME_COUNT))
+    capture.release()
+    return {"width": width, "height": height, "frame_count": frame_count}
+
+
+def _cost(states, positions: np.ndarray, used_mask: np.ndarray) -> float:
+    if not states:
+        return float("inf")
+
+    vertical_errors: List[float] = []
+    safety_penalties: List[float] = []
+
+    for state, pos, used in zip(states, positions, used_mask):
+        if not used or np.isnan(pos).any():
+            continue
+        crop_left = state.cx - state.crop_w / 2.0
+        crop_top = state.cy - state.crop_h / 2.0
+        rel_x = (pos[0] - crop_left) / max(state.crop_w, 1e-6)
+        rel_y = (pos[1] - crop_top) / max(state.crop_h, 1e-6)
+        vertical_errors.append((rel_y - 0.4) ** 2)
+        edge_distance = min(rel_x, 1.0 - rel_x, rel_y, 1.0 - rel_y)
+        safety_penalties.append(max(0.0, 0.12 - edge_distance) ** 2)
+
+    if not vertical_errors:
+        return float("inf")
+
+    cx_values = np.array([s.cx for s in states], dtype=np.float32)
+    zoom_values = np.array([s.zoom for s in states], dtype=np.float32)
+    if len(cx_values) >= 3:
+        lateral_acc = np.diff(cx_values, n=2)
+    else:
+        lateral_acc = np.array([0.0], dtype=np.float32)
+    if len(zoom_values) >= 3:
+        zoom_acc = np.diff(zoom_values, n=2)
+    else:
+        zoom_acc = np.array([0.0], dtype=np.float32)
+
+    total = (
+        float(np.mean(vertical_errors)) * 4.0
+        + float(np.mean(np.square(lateral_acc))) * 0.6
+        + float(np.mean(np.square(zoom_acc))) * 0.4
+        + (float(np.mean(safety_penalties)) if safety_penalties else 0.0) * 2.5
+    )
+    return total
+
+
+def _evaluate(config: Dict[str, float], width: int, height: int, fps: float, portrait, positions, used_mask) -> float:
+    planner = CameraPlanner(
+        width=width,
+        height=height,
+        fps=fps,
+        lookahead=int(config["lookahead"]),
+        smoothing=float(config["smoothing"]),
+        pad=float(config["pad"]),
+        speed_limit=float(config["speed_limit"]),
+        zoom_min=float(config.get("zoom_min", 1.0)),
+        zoom_max=float(config["zoom_max"]),
+        portrait=portrait,
+    )
+    states = planner.plan(positions, used_mask)
+    return _cost(states, positions, used_mask)
+
+
+def _save_preset(preset_name: str, values: Dict[str, float]) -> None:
+    ensure_presets_file()
+    presets = load_presets()
+    presets.setdefault(preset_name, {}).update(values)
+    with PRESETS_PATH.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(presets, handle, sort_keys=True)
+
+
+def run(args: argparse.Namespace) -> None:
+    input_path = Path(args.input).expanduser().resolve()
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input clip not found: {input_path}")
+
+    presets = load_presets()
+    preset_name = args.preset.lower()
+    if preset_name not in presets:
+        raise ValueError(f"Preset '{preset_name}' not present in {PRESETS_PATH}")
+
+    preset_config = presets[preset_name]
+    portrait = parse_portrait(preset_config.get("portrait")) if preset_config.get("portrait") else None
+
+    fps_in = ffprobe_fps(input_path)
+    fps = float(preset_config.get("fps", fps_in))
+    if fps <= 0:
+        fps = fps_in
+
+    meta = _video_metadata(input_path)
+
+    labels_root = Path(args.labels_root or "out/yolo").expanduser()
+    label_files = find_label_files(input_path.stem, labels_root)
+    labels = load_labels(label_files, meta["width"], meta["height"])
+    positions, used_mask = interp_labels_to_fps(labels, meta["frame_count"], fps_in, fps)
+
+    base_config = {
+        "lookahead": float(preset_config.get("lookahead", 18)),
+        "smoothing": float(preset_config.get("smoothing", 0.65)),
+        "pad": float(preset_config.get("pad", 0.22)),
+        "speed_limit": float(preset_config.get("speed_limit", 480)),
+        "zoom_max": float(preset_config.get("zoom_max", 2.2)),
+        "zoom_min": float(preset_config.get("zoom_min", 1.0)),
+    }
+
+    best_config = dict(base_config)
+    best_cost = _evaluate(best_config, meta["width"], meta["height"], fps, portrait, positions, used_mask)
+
+    rng = random.Random(args.seed)
+    for _ in range(args.iters):
+        candidate = dict(base_config)
+        candidate["lookahead"] = int(np.clip(rng.gauss(base_config["lookahead"], 3.0), 4, 36))
+        candidate["smoothing"] = float(np.clip(rng.gauss(base_config["smoothing"], 0.05), 0.4, 0.85))
+        candidate["pad"] = float(np.clip(rng.gauss(base_config["pad"], 0.02), 0.12, 0.30))
+        candidate["speed_limit"] = float(np.clip(rng.gauss(base_config["speed_limit"], 60.0), 240, 680))
+        candidate["zoom_max"] = float(np.clip(rng.gauss(base_config["zoom_max"], 0.1), 1.6, 2.6))
+        cost_value = _evaluate(candidate, meta["width"], meta["height"], fps, portrait, positions, used_mask)
+        if cost_value < best_cost:
+            best_cost = cost_value
+            best_config.update(candidate)
+
+    if best_config != base_config:
+        _save_preset(preset_name, best_config)
+
+    log_dir = Path("out/render_logs")
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / f"{input_path.stem}_calib.json"
+    payload = {
+        "preset": preset_name,
+        "input": str(input_path),
+        "iterations": args.iters,
+        "base": base_config,
+        "best": best_config,
+        "cost": best_cost,
+    }
+    with log_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)
+
+    print(f"Updated preset '{preset_name}' with cost {best_cost:.4f}. Settings written to {PRESETS_PATH}.")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Calibrate unified renderer presets")
+    parser.add_argument("--in", dest="input", required=True, help="Tester clip MP4 path")
+    parser.add_argument("--labels-root", dest="labels_root", help="Root folder with YOLO labels")
+    parser.add_argument("--preset", dest="preset", default="cinematic", help="Preset to adjust")
+    parser.add_argument("--iters", dest="iters", type=int, default=200, help="Random search iterations")
+    parser.add_argument("--seed", dest="seed", type=int, default=42, help="Deterministic seed")
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/overlay_debug.py
+++ b/tools/overlay_debug.py
@@ -1,0 +1,152 @@
+"""Overlay telemetry visualisations for QC."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import List, Optional
+
+import cv2  # type: ignore
+import numpy as np
+
+from render_follow_unified import (
+    ffprobe_fps,
+    find_label_files,
+    interp_labels_to_fps,
+    load_labels,
+)
+
+
+def _read_telemetry(path: Path) -> List[dict]:
+    records: List[dict] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            records.append(json.loads(stripped))
+    if not records:
+        raise RuntimeError(f"Telemetry file {path} is empty")
+    return records
+
+
+def _load_frames(path: Path, flip: bool) -> List[np.ndarray]:
+    cap = cv2.VideoCapture(str(path))
+    if not cap.isOpened():
+        raise RuntimeError(f"Unable to open video {path}")
+    frames: List[np.ndarray] = []
+    while True:
+        ok, frame = cap.read()
+        if not ok:
+            break
+        if flip:
+            frame = cv2.rotate(frame, cv2.ROTATE_180)
+        frames.append(frame)
+    cap.release()
+    if not frames:
+        raise RuntimeError("No frames decoded from input clip")
+    return frames
+
+
+def _sample_frame(frames: List[np.ndarray], fps_in: float, fps_out: float, index: int) -> np.ndarray:
+    t = float(index) / float(fps_out)
+    src_idx = int(round(t * fps_in))
+    src_idx = max(0, min(src_idx, len(frames) - 1))
+    return frames[src_idx]
+
+
+def _draw(frame: np.ndarray, telemetry: dict, label_point: Optional[np.ndarray]) -> np.ndarray:
+    output = frame.copy()
+    cx = telemetry.get("cx", 0.0)
+    cy = telemetry.get("cy", 0.0)
+    crop_w = telemetry.get("crop_w", 0.0)
+    crop_h = telemetry.get("crop_h", 0.0)
+
+    x1 = int(round(cx - crop_w / 2.0))
+    y1 = int(round(cy - crop_h / 2.0))
+    x2 = int(round(cx + crop_w / 2.0))
+    y2 = int(round(cy + crop_h / 2.0))
+    cv2.rectangle(output, (x1, y1), (x2, y2), (0, 255, 0), 2)
+
+    if label_point is not None and not np.isnan(label_point).any():
+        cv2.circle(output, (int(label_point[0]), int(label_point[1])), 8, (0, 0, 255), -1)
+
+    used = telemetry.get("used_label", False)
+    clamp = telemetry.get("clamp_flags", [])
+    text = f"used_label={used} zoom={telemetry.get('zoom', 0.0):.2f}"
+    if clamp:
+        text += f" clamps={','.join(clamp)}"
+    cv2.putText(output, text, (32, 48), cv2.FONT_HERSHEY_SIMPLEX, 1.0, (255, 255, 255), 2)
+    return output
+
+
+def run(args: argparse.Namespace) -> None:
+    input_path = Path(args.input).expanduser().resolve()
+    telemetry_path = Path(args.telemetry).expanduser().resolve()
+    if not input_path.exists():
+        raise FileNotFoundError(f"Input clip not found: {input_path}")
+    if not telemetry_path.exists():
+        raise FileNotFoundError(f"Telemetry file not found: {telemetry_path}")
+
+    records = _read_telemetry(telemetry_path)
+    fps_in = ffprobe_fps(input_path)
+    if len(records) > 1:
+        dt = np.median(np.diff([rec["t"] for rec in records]))
+        fps_out = 1.0 / max(dt, 1e-6)
+    else:
+        fps_out = fps_in
+
+    frames = _load_frames(input_path, args.flip180)
+
+    labels_root = Path(args.labels_root) if args.labels_root else None
+    label_points = None
+    if labels_root is not None:
+        labels_root = labels_root.expanduser()
+        labels = load_labels(
+            find_label_files(input_path.stem, labels_root),
+            frames[0].shape[1],
+            frames[0].shape[0],
+        )
+        positions, _ = interp_labels_to_fps(labels, len(frames), fps_in, fps_out)
+        label_points = positions
+
+    height, width = frames[0].shape[:2]
+    output_size = (width, height)
+    out_path = Path(args.output).expanduser().resolve() if args.output else input_path.with_suffix(".__DEBUG.mp4")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(str(out_path), fourcc, fps_out, output_size)
+    if not writer.isOpened():
+        raise RuntimeError(f"Unable to open writer for {out_path}")
+
+    for idx, telemetry in enumerate(records):
+        frame = _sample_frame(frames, fps_in, fps_out, idx)
+        point = None
+        if label_points is not None and idx < len(label_points):
+            point = label_points[idx]
+        rendered = _draw(frame, telemetry, point)
+        writer.write(rendered)
+
+    writer.release()
+    print(f"Wrote debug overlay to {out_path}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Overlay telemetry on a clip for QC")
+    parser.add_argument("--in", dest="input", required=True, help="Source MP4")
+    parser.add_argument("--telemetry", dest="telemetry", required=True, help="Telemetry JSONL path")
+    parser.add_argument("--out", dest="output", help="Output MP4 path")
+    parser.add_argument("--labels-root", dest="labels_root", help="Optional labels root for ball point rendering")
+    parser.add_argument("--flip180", dest="flip180", action="store_true", help="Apply 180-degree rotation before drawing")
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/render_follow_unified.py
+++ b/tools/render_follow_unified.py
@@ -1,713 +1,798 @@
-#!/usr/bin/env python3
-"""Unified render-follow / auto-zoom pipeline.
+"""Unified ball-lock renderer.
 
-This CLI replaces the historical ``render_follow_*`` variants with a single
-entrypoint that supports presets, portrait framing, branding, and YOLO ball
-label integration.  The pipeline stays streaming-friendly (no full video loads)
-and only depends on Python, NumPy, OpenCV, and ffmpeg being present.
+This script consolidates the historical ``render_follow_*`` variants into a single
+implementation that reproduces the behaviour of the "good tester clip" while
+remaining configurable through presets and CLI overrides.
+
+The module is intentionally self-contained so that the calibration and debug
+helpers can import and reuse the building blocks (label loading, camera
+planning, etc.).  The implementation is optimised for clarity and predictable
+Windows behaviour rather than raw performance.
 """
+
 from __future__ import annotations
 
 import argparse
 import json
+import logging
+import math
 import shutil
 import subprocess
 import sys
-import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import List, Optional, Sequence, Tuple
 
 import cv2  # type: ignore
 import numpy as np
+import yaml
 
-# ---------------------------------------------------------------------------
-# Preset definitions
-# ---------------------------------------------------------------------------
 
-PRESETS: Dict[str, Dict[str, float]] = {
+PRESETS_PATH = Path(__file__).resolve().parent / "render_presets.yaml"
+DEFAULT_PRESETS = {
     "cinematic": {
-        "lookahead": 18.0,
+        "fps": 30,
+        "portrait": "1080x1920",
+        "lookahead": 18,
         "smoothing": 0.65,
         "pad": 0.22,
-        "speed_limit": 0.035,  # fraction of frame width per frame
-        "zoom_speed": 0.08,     # fraction of frame width per frame
+        "speed_limit": 480,
+        "zoom_min": 1.0,
+        "zoom_max": 2.2,
+        "crf": 19,
+        "keyint_factor": 4,
     },
     "gentle": {
-        "lookahead": 12.0,
+        "fps": 30,
+        "portrait": "1080x1920",
+        "lookahead": 12,
         "smoothing": 0.55,
-        "pad": 0.28,
-        "speed_limit": 0.030,
-        "zoom_speed": 0.06,
+        "pad": 0.20,
+        "speed_limit": 360,
+        "zoom_min": 1.0,
+        "zoom_max": 1.8,
+        "crf": 20,
+        "keyint_factor": 4,
     },
     "realzoom": {
-        "lookahead": 16.0,
-        "smoothing": 0.60,
+        "fps": 30,
+        "portrait": "1080x1920",
+        "lookahead": 10,
+        "smoothing": 0.50,
         "pad": 0.18,
-        "speed_limit": 0.045,
-        "zoom_speed": 0.10,
+        "speed_limit": 520,
+        "zoom_min": 1.0,
+        "zoom_max": 2.4,
+        "crf": 19,
+        "keyint_factor": 4,
     },
 }
 
-DEFAULT_PRESET = "cinematic"
-DEFAULT_FPS = 30.0
-DEFAULT_LABELS_ROOT = Path("out") / "yolo"
-DEFAULT_LOG_ROOT = Path("out") / "render_logs"
-DEFAULT_TEMP_ROOT = Path("out") / "autoframe_work"
 
-# ---------------------------------------------------------------------------
-# Argument parsing
-# ---------------------------------------------------------------------------
+def ensure_presets_file() -> None:
+    """Create the presets file with defaults when missing."""
+
+    if PRESETS_PATH.exists():
+        return
+    PRESETS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with PRESETS_PATH.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(DEFAULT_PRESETS, handle, sort_keys=True)
+
+
+def load_presets() -> dict:
+    """Load the preset configuration, creating defaults if required."""
+
+    ensure_presets_file()
+    with PRESETS_PATH.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    return data
+
+
+def ffprobe_fps(path: Path) -> float:
+    """Return the floating-point FPS using ffprobe."""
+
+    command = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-select_streams",
+        "v:0",
+        "-show_entries",
+        "stream=r_frame_rate",
+        "-of",
+        "default=noprint_wrappers=1:nokey=1",
+        str(path),
+    ]
+    try:
+        result = subprocess.run(
+            command,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:  # pragma: no cover - execution context dependant
+        raise RuntimeError(
+            "Failed to read FPS using ffprobe. Ensure ffmpeg is installed and on PATH."
+        ) from exc
+
+    value = result.stdout.strip()
+    if not value:
+        raise RuntimeError("ffprobe did not return a frame rate value.")
+
+    if "/" in value:
+        num, den = value.split("/", 1)
+        den_value = float(den)
+        if den_value == 0:
+            return float(num)
+        return float(num) / den_value
+    return float(value)
 
 
 def parse_portrait(value: Optional[str]) -> Optional[Tuple[int, int]]:
+    """Convert a WxH string into integers."""
+
     if not value:
         return None
     parts = value.lower().split("x")
     if len(parts) != 2:
-        raise argparse.ArgumentTypeError("--portrait must be WIDTHxHEIGHT")
-    try:
-        width = int(parts[0])
-        height = int(parts[1])
-    except ValueError as exc:  # pragma: no cover - argparse handles message
-        raise argparse.ArgumentTypeError("--portrait must be WIDTHxHEIGHT") from exc
+        raise ValueError(f"Invalid portrait specification: {value}")
+    width = int(parts[0])
+    height = int(parts[1])
     if width <= 0 or height <= 0:
-        raise argparse.ArgumentTypeError("--portrait dimensions must be >0")
+        raise ValueError("Portrait dimensions must be positive integers.")
     return width, height
 
 
-def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description="Unified render-follow / auto-zoom pipeline",
-        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-    )
-    parser.add_argument("--in", "--src", dest="input", required=True,
-                        help="Input MP4 clip")
-    parser.add_argument("--out", dest="output", help="Output MP4 path")
-    parser.add_argument("--preset", choices=sorted(PRESETS.keys()),
-                        default=DEFAULT_PRESET,
-                        help="Rendering preset")
-    parser.add_argument("--portrait", type=parse_portrait,
-                        help="Portrait canvas WxH")
-    parser.add_argument("--fps", type=float,
-                        help="Output frames per second (defaults to input fps)")
-    parser.add_argument("--flip180", action="store_true",
-                        help="Rotate frames 180 degrees before processing")
-    parser.add_argument("--labels-root", default=str(DEFAULT_LABELS_ROOT),
-                        help="Root directory for YOLO ball labels")
-    parser.add_argument("--clean-temp", action="store_true",
-                        help="Clean temp work directory before rendering")
-    parser.add_argument("--brand-overlay", dest="brand_overlay",
-                        help="PNG overlay composited on top of frames")
-    parser.add_argument("--endcard", dest="endcard",
-                        help="PNG endcard appended (~1s) to final video")
-    parser.add_argument("--lookahead", type=float,
-                        help="Override lookahead window (frames)")
-    parser.add_argument("--smoothing", type=float,
-                        help="Override smoothing factor (0-1)")
-    parser.add_argument("--pad", type=float,
-                        help="Override fractional padding for camera window")
-    parser.add_argument("--log", dest="log_path",
-                        help="Optional path for render log")
-    parser.add_argument("--jsonl-telemetry", dest="telemetry",
-                        help="Optional JSONL debug output for per-frame camera")
-    parser.add_argument("--quiet", action="store_true",
-                        help="Reduce console output")
-    return parser.parse_args(argv)
+def find_label_files(stem: str, labels_root: Path) -> List[Path]:
+    """Discover YOLO label shards matching ``<stem>_*.txt``."""
 
-
-# ---------------------------------------------------------------------------
-# ffprobe helpers
-# ---------------------------------------------------------------------------
-
-
-def run_subprocess(cmd: Sequence[str], capture_output: bool = False) -> subprocess.CompletedProcess:
-    if capture_output:
-        return subprocess.run(cmd, check=True, stdout=subprocess.PIPE,
-                              stderr=subprocess.PIPE, text=True)
-    return subprocess.run(cmd, check=True)
-
-
-def ffprobe_stream_info(path: Path) -> Dict[str, Optional[float]]:
-    cmd = [
-        "ffprobe", "-v", "error",
-        "-select_streams", "v:0",
-        "-show_entries", "stream=width,height,avg_frame_rate,r_frame_rate,nb_frames",
-        "-of", "json",
-        str(path),
-    ]
-    result = run_subprocess(cmd, capture_output=True)
-    data = json.loads(result.stdout or "{}")
-    streams = data.get("streams", [])
-    if not streams:
-        raise RuntimeError(f"No video stream found in {path}")
-    stream = streams[0]
-
-    def parse_rate(rate: str) -> Optional[float]:
-        if not rate or rate == "0/0":
-            return None
-        if isinstance(rate, (int, float)):
-            return float(rate)
-        if "/" in rate:
-            num, den = rate.split("/", 1)
-            try:
-                num_f = float(num)
-                den_f = float(den)
-                if den_f:
-                    return num_f / den_f
-            except ValueError:
-                return None
-        else:
-            try:
-                return float(rate)
-            except ValueError:
-                return None
-        return None
-
-    width = stream.get("width")
-    height = stream.get("height")
-    avg_rate = parse_rate(stream.get("avg_frame_rate"))
-    real_rate = parse_rate(stream.get("r_frame_rate"))
-    fps = avg_rate or real_rate or DEFAULT_FPS
-    nb_frames = stream.get("nb_frames")
-    try:
-        total_frames = int(nb_frames) if nb_frames is not None else None
-    except (TypeError, ValueError):
-        total_frames = None
-    return {
-        "width": width,
-        "height": height,
-        "fps": fps,
-        "frames": total_frames,
-    }
-
-
-# ---------------------------------------------------------------------------
-# Label handling
-# ---------------------------------------------------------------------------
-
-
-def _split_tokens(line: str) -> List[str]:
-    line = line.strip()
-    if not line:
+    if not labels_root.exists():
         return []
-    return [part for part in line.replace(",", " ").split() if part]
+    pattern = f"**/labels/{stem}_*.txt"
+    return sorted(labels_root.glob(pattern))
+
+
+def load_labels(paths: Sequence[Path], frame_width: int, frame_height: int) -> np.ndarray:
+    """Load and merge labels from one or more shards.
+
+    Returns a numpy array with columns ``frame_idx``, ``x`` and ``y`` in pixel space.
+    Outliers (z-score > 3) are discarded.
+    """
+
+    records: List[Tuple[int, float, float]] = []
+    for file_path in paths:
+        with file_path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#"):
+                    continue
+                parts = stripped.split()
+                if len(parts) < 3:
+                    continue
+                try:
+                    frame_idx = int(float(parts[0]))
+                    x_value = float(parts[1])
+                    y_value = float(parts[2])
+                except ValueError:
+                    continue
+                records.append((frame_idx, x_value, y_value))
+
+    if not records:
+        return np.empty((0, 3), dtype=np.float32)
+
+    data = np.array(records, dtype=np.float32)
+    xs = data[:, 1]
+    ys = data[:, 2]
+    if np.nanmax(xs) <= 1.5 and np.nanmax(ys) <= 1.5:
+        data[:, 1] = xs * float(frame_width)
+        data[:, 2] = ys * float(frame_height)
+
+    # Sort and drop duplicates (keeping the highest frame index entry first in chronological order)
+    order = np.argsort(data[:, 0])
+    data = data[order]
+    _, unique_indices = np.unique(data[:, 0], return_index=True)
+    data = data[np.sort(unique_indices)]
+
+    mean_x = float(np.mean(data[:, 1]))
+    std_x = float(np.std(data[:, 1]))
+    mean_y = float(np.mean(data[:, 2]))
+    std_y = float(np.std(data[:, 2]))
+    keep_mask = np.ones(len(data), dtype=bool)
+    if std_x > 1e-6:
+        keep_mask &= np.abs((data[:, 1] - mean_x) / std_x) <= 3.0
+    if std_y > 1e-6:
+        keep_mask &= np.abs((data[:, 2] - mean_y) / std_y) <= 3.0
+    filtered = data[keep_mask]
+    return filtered
+
+
+def _interpolate(values: np.ndarray, times: np.ndarray, target_times: np.ndarray) -> np.ndarray:
+    """Helper performing linear interpolation with edge clamping."""
+
+    if len(values) == 0:
+        return np.full_like(target_times, np.nan, dtype=np.float32)
+    left = values[0]
+    right = values[-1]
+    return np.interp(target_times, times, values, left=left, right=right)
+
+
+def interp_labels_to_fps(
+    labels: np.ndarray,
+    frame_count: int,
+    src_fps: float,
+    dst_fps: float,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Resample label positions to the render FPS.
+
+    Returns ``(positions, used_mask)`` where ``positions`` is ``Nx2`` with NaNs for
+    missing data and ``used_mask`` marks frames that were close to a labelled
+    position.
+    """
+
+    if len(labels) == 0 or frame_count <= 0:
+        positions = np.full((frame_count, 2), np.nan, dtype=np.float32)
+        used = np.zeros(frame_count, dtype=bool)
+        return positions, used
+
+    times = labels[:, 0] / float(src_fps)
+    xs = labels[:, 1]
+    ys = labels[:, 2]
+
+    duration = float(frame_count) / float(src_fps)
+    target_count = max(1, int(round(duration * float(dst_fps))))
+    target_times = np.arange(target_count, dtype=np.float32) / float(dst_fps)
+
+    interp_x = _interpolate(xs, times, target_times)
+    interp_y = _interpolate(ys, times, target_times)
+
+    positions = np.stack([interp_x, interp_y], axis=1).astype(np.float32)
+
+    used = np.zeros(target_count, dtype=bool)
+    threshold = 1.5 / float(dst_fps)
+    for idx, t_value in enumerate(target_times):
+        diff = np.abs(times - t_value)
+        if diff.size and float(np.min(diff)) <= threshold:
+            used[idx] = True
+
+    return positions, used
 
 
 @dataclass
-class LabelEntry:
+class CamState:
     frame: int
-    x: float
-    y: float
-    score: Optional[float] = None
-
-
-class LabelStore:
-    def __init__(self, labels_root: Path):
-        self.labels_root = labels_root
-
-    def find_label_files(self, stem: str) -> List[Path]:
-        if not self.labels_root.exists():
-            return []
-        pattern = f"{stem}_*.txt"
-        matches: List[Path] = []
-        for labels_dir in self.labels_root.glob("**/labels"):
-            if labels_dir.is_dir():
-                matches.extend(sorted(labels_dir.glob(pattern)))
-        return sorted(matches)
-
-    def load_labels(self, stem: str) -> List[LabelEntry]:
-        label_files = self.find_label_files(stem)
-        entries: List[LabelEntry] = []
-        for file_path in label_files:
-            try:
-                with file_path.open("r", encoding="utf-8") as fh:
-                    for line in fh:
-                        tokens = _split_tokens(line)
-                        if len(tokens) < 3:
-                            continue
-                        try:
-                            frame_idx = int(float(tokens[0]))
-                            x = float(tokens[1])
-                            y = float(tokens[2])
-                            score = float(tokens[3]) if len(tokens) > 3 else None
-                        except ValueError:
-                            continue
-                        entries.append(LabelEntry(frame=frame_idx, x=x, y=y, score=score))
-            except FileNotFoundError:
-                continue
-        entries.sort(key=lambda e: (e.frame, -(e.score or 0.0)))
-        return entries
-
-    def build_sequence(self, stem: str, frame_count: int) -> List[Optional[Tuple[float, float]]]:
-        entries = self.load_labels(stem)
-        if frame_count <= 0:
-            return []
-        sequence: List[Optional[Tuple[float, float]]] = [None] * frame_count
-        for entry in entries:
-            for candidate in (entry.frame, entry.frame - 1):
-                if 0 <= candidate < frame_count:
-                    sequence[candidate] = (entry.x, entry.y)
-                    break
-        if not any(sequence):
-            return [None] * frame_count
-        # forward / backward fill sparse labels for stability
-        last_known: Optional[Tuple[float, float]] = None
-        for idx, value in enumerate(sequence):
-            if value is None and last_known is not None:
-                sequence[idx] = last_known
-            elif value is not None:
-                last_known = value
-        last_known = None
-        for idx in range(frame_count - 1, -1, -1):
-            value = sequence[idx]
-            if value is None and last_known is not None:
-                sequence[idx] = last_known
-            elif value is not None:
-                last_known = value
-        return sequence
-
-
-# ---------------------------------------------------------------------------
-# Camera planning
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class CameraState:
-    x: float
-    y: float
-    width: float
-    height: float
+    cx: float
+    cy: float
     zoom: float
-    target: Tuple[float, float]
+    crop_w: float
+    crop_h: float
+    used_label: bool
+    clamp_flags: List[str]
 
 
 class CameraPlanner:
+    """Planner that tracks the ball and produces smoothed camera states."""
+
     def __init__(
         self,
-        frame_size: Tuple[int, int],
-        canvas_size: Tuple[int, int],
+        width: int,
+        height: int,
         fps: float,
-        lookahead: float,
+        lookahead: int,
         smoothing: float,
         pad: float,
         speed_limit: float,
-        zoom_speed: float,
-        focus_x: float,
-        focus_y: float,
+        zoom_min: float,
+        zoom_max: float,
+        portrait: Optional[Tuple[int, int]] = None,
     ) -> None:
-        self.frame_w, self.frame_h = frame_size
-        self.canvas_w, self.canvas_h = canvas_size
-        self.aspect = self.canvas_w / self.canvas_h
-        self.fps = max(fps, 1.0)
-        self.lookahead = max(0, int(round(lookahead)))
-        self.smoothing = float(np.clip(smoothing, 0.0, 0.99))
-        self.pad = max(0.0, pad)
-        self.speed_limit = max(0.0, speed_limit)
-        self.zoom_speed = max(0.001, zoom_speed)
-        self.focus_x = focus_x
-        self.focus_y = focus_y
-        self.min_crop_width = float(self.frame_w) / 3.2
-        self.max_crop_width = float(self.frame_w)
+        self.width = float(width)
+        self.height = float(height)
+        self.fps = float(fps)
+        self.lookahead = max(0, int(lookahead))
+        self.smoothing = float(np.clip(smoothing, 0.0, 1.0))
+        self.pad = max(0.0, min(0.45, float(pad)))
+        self.speed_limit = max(0.0, float(speed_limit))
+        self.zoom_min = max(0.1, float(zoom_min))
+        self.zoom_max = max(self.zoom_min, float(zoom_max))
+        self.portrait = portrait
 
-    def _fallback_position(self) -> Tuple[float, float]:
-        # Keep the ball roughly 60% up from the bottom in the portrait output.
-        return (self.frame_w / 2.0, self.frame_h * 0.4)
+        base_side = min(self.width, self.height)
+        base_side = max(1.0, base_side)
+        desired_side = max(base_side * (1.0 - 2.0 * self.pad), base_side * 0.35)
+        desired_zoom = base_side / desired_side
+        self.base_zoom = float(np.clip(desired_zoom, self.zoom_min, self.zoom_max))
 
-    def _window_stats(self, positions: np.ndarray, idx: int) -> Tuple[Tuple[float, float], float, float]:
-        end = min(len(positions), idx + self.lookahead + 1)
-        window = positions[idx:end]
-        valid_mask = ~np.isnan(window[:, 0])
-        valid = window[valid_mask]
-        if valid.size == 0:
-            target = self._fallback_position()
-            span_x = self.min_crop_width * 0.6
-            span_y = (self.min_crop_width / self.aspect) * 0.6
-        else:
-            xs = valid[:, 0]
-            ys = valid[:, 1]
-            target = (float(xs[-1]), float(ys[-1]))
-            span_x = float(xs.max() - xs.min())
-            span_y = float(ys.max() - ys.min())
-            span_x = max(span_x, 12.0)
-            span_y = max(span_y, 8.0)
-        span_x *= (1.0 + self.pad)
-        span_y *= (1.0 + self.pad)
-        return target, span_x, span_y
-
-    def plan(self, positions: Sequence[Optional[Tuple[float, float]]]) -> List[CameraState]:
+    def plan(self, positions: np.ndarray, used_mask: np.ndarray) -> List[CamState]:
         frame_count = len(positions)
-        if frame_count == 0:
-            return []
-        arr = np.full((frame_count, 2), np.nan, dtype=float)
-        for i, pos in enumerate(positions):
-            if pos is not None:
-                arr[i, 0] = float(pos[0])
-                arr[i, 1] = float(pos[1])
-        smoothing_alpha = max(0.01, 1.0 - self.smoothing)
-        max_dx = self.speed_limit * self.frame_w
-        max_dy = self.speed_limit * self.frame_h
-        max_zoom_delta = self.zoom_speed * self.frame_w
+        states: List[CamState] = []
+        prev_cx = self.width / 2.0
+        prev_cy = self.height / 2.0
+        prev_zoom = self.base_zoom
+        fallback_center = np.array([prev_cx, self.height * 0.45], dtype=np.float32)
+        fallback_alpha = 0.05
+        per_frame_speed = self.speed_limit / max(self.fps, 0.001)
 
-        states: List[CameraState] = []
-        prev_ball_x, prev_ball_y = self._fallback_position()
-        prev_crop_w = min(self.max_crop_width, max(self.min_crop_width, self.frame_w * 0.8))
-        prev_crop_h = prev_crop_w / self.aspect
-        prev_cam_x = max(0.0, min(prev_ball_x - self.focus_x * prev_crop_w, self.frame_w - prev_crop_w))
-        prev_cam_y = max(0.0, min(prev_ball_y - self.focus_y * prev_crop_h, self.frame_h - prev_crop_h))
+        aspect_target = None
+        if self.portrait:
+            aspect_target = float(self.portrait[0]) / float(self.portrait[1])
 
-        for idx in range(frame_count):
-            target, span_x, span_y = self._window_stats(arr, idx)
-            ball_x = prev_ball_x + smoothing_alpha * (target[0] - prev_ball_x)
-            ball_y = prev_ball_y + smoothing_alpha * (target[1] - prev_ball_y)
+        for frame_idx in range(frame_count):
+            pos = positions[frame_idx]
+            has_position = bool(used_mask[frame_idx]) and not np.isnan(pos).any()
 
-            desired_crop_w = max(self.min_crop_width, min(self.max_crop_width, max(span_x, self.aspect * span_y)))
-            crop_w = prev_crop_w + np.clip(desired_crop_w - prev_crop_w, -max_zoom_delta, max_zoom_delta)
-            crop_w = float(np.clip(crop_w, self.min_crop_width, self.max_crop_width))
-            crop_h = float(crop_w / self.aspect)
+            if has_position:
+                target = pos.copy()
+            else:
+                fallback_target = np.array([self.width / 2.0, self.height * 0.40], dtype=np.float32)
+                fallback_center = (
+                    fallback_alpha * fallback_target + (1.0 - fallback_alpha) * fallback_center
+                )
+                target = fallback_center
 
-            cam_x = ball_x - self.focus_x * crop_w
-            cam_y = ball_y - self.focus_y * crop_h
+            # Lookahead bias.
+            if self.lookahead > 0 and frame_idx < frame_count - 1:
+                max_future = min(frame_count - 1, frame_idx + self.lookahead)
+                future_positions = positions[frame_idx + 1 : max_future + 1]
+                future_mask = used_mask[frame_idx + 1 : max_future + 1]
+                valid_future = future_positions[future_mask]
+                if valid_future.size:
+                    future_mean = valid_future.mean(axis=0)
+                    target = 0.65 * target + 0.35 * future_mean
 
-            cam_x = prev_cam_x + np.clip(cam_x - prev_cam_x, -max_dx, max_dx)
-            cam_y = prev_cam_y + np.clip(cam_y - prev_cam_y, -max_dy, max_dy)
+            target_zoom = self.base_zoom
 
-            cam_x = float(np.clip(cam_x, 0.0, max(0.0, self.frame_w - crop_w)))
-            cam_y = float(np.clip(cam_y, 0.0, max(0.0, self.frame_h - crop_h)))
-            zoom = float(self.frame_w / crop_w) if crop_w else 1.0
+            smoothed_cx = self.smoothing * target[0] + (1.0 - self.smoothing) * prev_cx
+            smoothed_cy = self.smoothing * target[1] + (1.0 - self.smoothing) * prev_cy
+            smoothed_zoom = self.smoothing * target_zoom + (1.0 - self.smoothing) * prev_zoom
 
-            states.append(CameraState(x=cam_x, y=cam_y, width=crop_w, height=crop_h,
-                                      zoom=zoom, target=(ball_x, ball_y)))
+            clamp_flags: List[str] = []
 
-            prev_ball_x, prev_ball_y = ball_x, ball_y
-            prev_crop_w, prev_crop_h = crop_w, crop_h
-            prev_cam_x, prev_cam_y = cam_x, cam_y
+            # Limit the camera speed.
+            dx = smoothed_cx - prev_cx
+            dy = smoothed_cy - prev_cy
+            distance = math.hypot(dx, dy)
+            if per_frame_speed > 0 and distance > per_frame_speed:
+                ratio = per_frame_speed / distance
+                smoothed_cx = prev_cx + dx * ratio
+                smoothed_cy = prev_cy + dy * ratio
+                clamp_flags.append("speed")
+
+            smoothed_zoom = float(np.clip(smoothed_zoom, self.zoom_min, self.zoom_max))
+
+            crop_w = self.width / smoothed_zoom
+            crop_h = self.height / smoothed_zoom
+
+            if aspect_target:
+                current_aspect = crop_w / crop_h
+                if current_aspect > aspect_target:
+                    crop_w = crop_h * aspect_target
+                else:
+                    crop_h = crop_w / aspect_target
+
+            # Bias the framing so the ball sits lower in portrait compositions.
+            if aspect_target:
+                desired_center_y = smoothed_cy + 0.10 * crop_h
+                smoothed_cy = desired_center_y
+
+            half_w = crop_w / 2.0
+            half_h = crop_h / 2.0
+
+            min_cx = half_w
+            max_cx = self.width - half_w
+            min_cy = half_h
+            max_cy = self.height - half_h
+
+            if smoothed_cx < min_cx:
+                smoothed_cx = min_cx
+                clamp_flags.append("bounds")
+            if smoothed_cx > max_cx:
+                smoothed_cx = max_cx
+                clamp_flags.append("bounds")
+            if smoothed_cy < min_cy:
+                smoothed_cy = min_cy
+                clamp_flags.append("bounds")
+            if smoothed_cy > max_cy:
+                smoothed_cy = max_cy
+                clamp_flags.append("bounds")
+
+            prev_cx = smoothed_cx
+            prev_cy = smoothed_cy
+            prev_zoom = smoothed_zoom
+
+            states.append(
+                CamState(
+                    frame=frame_idx,
+                    cx=smoothed_cx,
+                    cy=smoothed_cy,
+                    zoom=smoothed_zoom,
+                    crop_w=crop_w,
+                    crop_h=crop_h,
+                    used_label=bool(has_position),
+                    clamp_flags=clamp_flags,
+                )
+            )
 
         return states
 
 
-# ---------------------------------------------------------------------------
-# Rendering pipeline
-# ---------------------------------------------------------------------------
+def _load_overlay(path: Optional[Path], output_size: Tuple[int, int]) -> Optional[np.ndarray]:
+    if not path:
+        return None
+    if not path.exists():
+        logging.warning("Brand overlay %s not found; skipping.", path)
+        return None
+    image = cv2.imread(str(path), cv2.IMREAD_UNCHANGED)
+    if image is None:
+        logging.warning("Failed to read brand overlay at %s; skipping.", path)
+        return None
+    resized = cv2.resize(image, output_size, interpolation=cv2.INTER_LINEAR)
+    return resized
+
+
+def _apply_overlay(frame: np.ndarray, overlay: np.ndarray) -> np.ndarray:
+    if overlay.shape[2] < 4:
+        return cv2.addWeighted(frame, 0.7, overlay[:, :, :3], 0.3, 0.0)
+    alpha = overlay[:, :, 3:] / 255.0
+    base = frame.astype(np.float32)
+    overlay_rgb = overlay[:, :, :3].astype(np.float32)
+    blended = overlay_rgb * alpha + base * (1.0 - alpha)
+    return blended.astype(np.uint8)
 
 
 class Renderer:
-    def __init__(self, args: argparse.Namespace, video_info: Dict[str, Optional[float]]) -> None:
-        self.args = args
-        self.input_path = Path(args.input).resolve()
-        self.video_info = video_info
-        self.preset = PRESETS[args.preset]
-        self.labels_root = Path(args.labels_root).resolve()
-        self.temp_root = DEFAULT_TEMP_ROOT / args.preset / self.input_path.stem
-        self.frames_dir = self.temp_root / "frames"
-        self.frames_pattern = self.frames_dir / "f_%06d.jpg"
-        self.clean_temp = bool(args.clean_temp)
-        self.overlay_path = Path(args.brand_overlay).resolve() if args.brand_overlay else None
-        self.endcard_path = Path(args.endcard).resolve() if args.endcard else None
-        self.telemetry_path = Path(args.telemetry).resolve() if args.telemetry else None
-        self.overlay_image: Optional[np.ndarray] = None
-        self.overlay_alpha: Optional[np.ndarray] = None
+    def __init__(
+        self,
+        input_path: Path,
+        output_path: Path,
+        temp_dir: Path,
+        fps_in: float,
+        fps_out: float,
+        flip180: bool,
+        portrait: Optional[Tuple[int, int]],
+        brand_overlay: Optional[Path],
+        endcard: Optional[Path],
+        telemetry_path: Optional[Path],
+    ) -> None:
+        self.input_path = input_path
+        self.output_path = output_path
+        self.temp_dir = temp_dir
+        self.fps_in = fps_in
+        self.fps_out = fps_out
+        self.flip180 = flip180
+        self.portrait = portrait
+        self.brand_overlay_path = brand_overlay
+        self.endcard_path = endcard
+        self.telemetry_path = telemetry_path
 
-        if args.output:
-            self.output_path = Path(args.output).resolve()
+    def _read_frames(self) -> List[np.ndarray]:
+        capture = cv2.VideoCapture(str(self.input_path))
+        if not capture.isOpened():
+            raise RuntimeError(f"Failed to open input video: {self.input_path}")
+        frames: List[np.ndarray] = []
+        while True:
+            ok, frame = capture.read()
+            if not ok:
+                break
+            if self.flip180:
+                frame = cv2.rotate(frame, cv2.ROTATE_180)
+            frames.append(frame)
+        capture.release()
+        if not frames:
+            raise RuntimeError("No frames decoded from the input video.")
+        return frames
+
+    def _sample_frame(self, frames: Sequence[np.ndarray], index: int) -> np.ndarray:
+        time_sec = float(index) / float(self.fps_out)
+        source_index = int(round(time_sec * float(self.fps_in)))
+        source_index = max(0, min(source_index, len(frames) - 1))
+        return frames[source_index]
+
+    def _compose_frame(
+        self,
+        frame: np.ndarray,
+        state: CamState,
+        output_size: Tuple[int, int],
+        overlay_image: Optional[np.ndarray],
+    ) -> np.ndarray:
+        height, width = frame.shape[:2]
+        crop_w = min(state.crop_w, float(width))
+        crop_h = min(state.crop_h, float(height))
+        x1 = int(round(state.cx - crop_w / 2.0))
+        y1 = int(round(state.cy - crop_h / 2.0))
+        x1 = max(0, min(x1, width - int(round(crop_w))))
+        y1 = max(0, min(y1, height - int(round(crop_h))))
+        x2 = int(round(x1 + crop_w))
+        y2 = int(round(y1 + crop_h))
+        x2 = max(x1 + 1, min(x2, width))
+        y2 = max(y1 + 1, min(y2, height))
+
+        cropped = frame[y1:y2, x1:x2]
+        if cropped.size == 0:
+            cropped = frame
+
+        resized = cv2.resize(cropped, output_size, interpolation=cv2.INTER_CUBIC)
+
+        if overlay_image is not None:
+            resized = _apply_overlay(resized, overlay_image)
+
+        return resized
+
+    def _append_endcard(self, output_size: Tuple[int, int]) -> List[np.ndarray]:
+        if not self.endcard_path:
+            return []
+        if not self.endcard_path.exists():
+            logging.warning("Endcard %s not found; skipping.", self.endcard_path)
+            return []
+        image = cv2.imread(str(self.endcard_path))
+        if image is None:
+            logging.warning("Failed to read endcard at %s; skipping.", self.endcard_path)
+            return []
+        resized = cv2.resize(image, output_size, interpolation=cv2.INTER_LINEAR)
+        frame_count = int(round(self.fps_out * 2.0))
+        return [resized for _ in range(frame_count)]
+
+    def write_frames(self, states: Sequence[CamState]) -> None:
+        frames = self._read_frames()
+        height, width = frames[0].shape[:2]
+        if self.portrait:
+            output_size = self.portrait
         else:
-            suffix = f".__{args.preset.upper()}.mp4"
-            self.output_path = self.input_path.with_name(self.input_path.name + suffix)
-        self.output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_size = (width, height)
 
-        if args.log_path:
-            self.log_path = Path(args.log_path).resolve()
-        else:
-            DEFAULT_LOG_ROOT.mkdir(parents=True, exist_ok=True)
-            log_name = f"{self.input_path.stem}__{args.preset}.log"
-            self.log_path = (DEFAULT_LOG_ROOT / log_name).resolve()
-        self.log_path.parent.mkdir(parents=True, exist_ok=True)
-
-        if args.portrait:
-            self.canvas_size = args.portrait
-        else:
-            width = int(video_info.get("width") or 0)
-            height = int(video_info.get("height") or 0)
-            if width <= 0 or height <= 0:
-                raise RuntimeError("Unable to determine input resolution")
-            self.canvas_size = (width, height)
-
-    # ------------------------------
-    def extract_frames(self, fps: float, quiet: bool = False) -> None:
-        if self.clean_temp and self.temp_root.exists():
-            shutil.rmtree(self.temp_root)
-        self.frames_dir.mkdir(parents=True, exist_ok=True)
-        cached = sorted(self.frames_dir.glob("f_*.jpg"))
-        if cached and not self.clean_temp:
-            if not quiet:
-                print(f"Reusing {len(cached)} cached frames in {self.frames_dir}")
-            return
-        if not quiet:
-            print("Extracting source frames...")
-        cmd = [
-            "ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
-            "-i", str(self.input_path),
-            "-vf", f"fps={fps:.6f}",
-            "-start_number", "0",
-            str(self.frames_pattern),
-        ]
-        run_subprocess(cmd)
-
-    def prepare_overlay(self) -> None:
-        if not self.overlay_path:
-            return
-        if not self.overlay_path.exists():
-            print(f"Warning: overlay not found: {self.overlay_path}")
-            self.overlay_path = None
-            return
-        overlay = cv2.imread(str(self.overlay_path), cv2.IMREAD_UNCHANGED)
-        if overlay is None:
-            print(f"Warning: failed to load overlay {self.overlay_path}")
-            self.overlay_path = None
-            return
-        overlay = cv2.resize(overlay, (self.canvas_size[0], self.canvas_size[1]), interpolation=cv2.INTER_AREA)
-        if overlay.shape[2] == 4:
-            alpha = overlay[:, :, 3].astype(np.float32) / 255.0
-            self.overlay_alpha = alpha[..., None]
-            self.overlay_image = overlay[:, :, :3].astype(np.float32)
-        else:
-            self.overlay_alpha = np.ones((overlay.shape[0], overlay.shape[1], 1), dtype=np.float32)
-            self.overlay_image = overlay.astype(np.float32)
-
-    def apply_overlay(self, frame: np.ndarray) -> np.ndarray:
-        if self.overlay_image is None or self.overlay_alpha is None:
-            return frame
-        overlay = self.overlay_image
-        alpha = self.overlay_alpha
-        if overlay.shape[0] != frame.shape[0] or overlay.shape[1] != frame.shape[1]:
-            overlay = cv2.resize(overlay, (frame.shape[1], frame.shape[0]), interpolation=cv2.INTER_AREA)
-            alpha = cv2.resize(alpha, (frame.shape[1], frame.shape[0]), interpolation=cv2.INTER_AREA)[..., None]
-        blended = overlay * alpha + frame.astype(np.float32) * (1.0 - alpha)
-        return np.clip(blended, 0, 255).astype(np.uint8)
-
-    def compose_frames(self, states: Sequence[CameraState], quiet: bool = False) -> int:
-        frame_files = sorted(self.frames_dir.glob("f_*.jpg"))
-        if len(frame_files) != len(states):
-            raise RuntimeError("Frame count mismatch between extracted frames and camera plan")
-        count = 0
-        telemetry_fh = None
+        overlay_image = _load_overlay(self.brand_overlay_path, output_size)
+        telemetry_file = None
         if self.telemetry_path:
             self.telemetry_path.parent.mkdir(parents=True, exist_ok=True)
-            telemetry_fh = self.telemetry_path.open("w", encoding="utf-8")
-        try:
-            for idx, frame_file in enumerate(frame_files):
-                bgr = cv2.imread(str(frame_file), cv2.IMREAD_COLOR)
-                if bgr is None:
-                    raise RuntimeError(f"Failed to load frame {frame_file}")
-                if self.args.flip180:
-                    bgr = cv2.rotate(bgr, cv2.ROTATE_180)
-                state = states[idx]
-                xi = int(round(state.x))
-                yi = int(round(state.y))
-                wi = int(round(state.width))
-                hi = int(round(state.height))
-                xi = max(0, min(xi, bgr.shape[1] - wi))
-                yi = max(0, min(yi, bgr.shape[0] - hi))
-                crop = bgr[yi:yi + hi, xi:xi + wi]
-                if crop.shape[0] != hi or crop.shape[1] != wi:
-                    pad_bottom = max(0, hi - crop.shape[0])
-                    pad_right = max(0, wi - crop.shape[1])
-                    crop = cv2.copyMakeBorder(crop, 0, pad_bottom, 0, pad_right, cv2.BORDER_REPLICATE)
-                resized = cv2.resize(crop, self.canvas_size, interpolation=cv2.INTER_LANCZOS4)
-                composited = self.apply_overlay(resized)
-                cv2.imwrite(str(frame_file), composited, [int(cv2.IMWRITE_JPEG_QUALITY), 97])
-                count += 1
-                if telemetry_fh:
-                    record = {
-                        "frame": idx,
-                        "camera": {
-                            "x": state.x,
-                            "y": state.y,
-                            "w": state.width,
-                            "h": state.height,
-                            "zoom": state.zoom,
-                        },
-                        "target": {
-                            "x": state.target[0],
-                            "y": state.target[1],
-                        },
-                    }
-                    telemetry_fh.write(json.dumps(record) + "\n")
-            if not quiet:
-                print(f"Rendered {count} frames into {self.frames_dir}")
-        finally:
-            if telemetry_fh:
-                telemetry_fh.close()
-        return count
+            telemetry_file = self.telemetry_path.open("w", encoding="utf-8")
 
-    def ffmpeg_stitch(self, fps: float, quiet: bool = False) -> None:
-        tmp_main = self.temp_root / "__main_video.mp4"
-        cmd = [
-            "ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
-            "-framerate", f"{fps:.6f}",
-            "-i", str(self.frames_pattern),
-            "-i", str(self.input_path),
-            "-map", "0:v:0",
-            "-map", "1:a:0?",
-            "-c:v", "libx264",
-            "-preset", "slow",
-            "-crf", "19",
-            "-pix_fmt", "yuv420p",
-            "-profile:v", "high",
-            "-g", str(int(round(fps * 4))),
-            "-shortest",
-            "-c:a", "aac",
-            "-b:a", "192k",
-            "-movflags", "+faststart",
-            str(tmp_main),
-        ]
-        run_subprocess(cmd)
-        if not self.endcard_path or not self.endcard_path.exists():
-            shutil.move(str(tmp_main), str(self.output_path))
-            if not quiet:
-                print(f"Wrote {self.output_path}")
-            return
+        for state in states:
+            frame = self._sample_frame(frames, state.frame)
+            composed = self._compose_frame(frame, state, output_size, overlay_image)
+            out_path = self.temp_dir / f"f_{state.frame:06d}.jpg"
+            success = cv2.imwrite(str(out_path), composed, [int(cv2.IMWRITE_JPEG_QUALITY), 95])
+            if not success:
+                raise RuntimeError(f"Failed to write frame to {out_path}")
+            if telemetry_file:
+                record = {
+                    "t": float(state.frame) / float(self.fps_out),
+                    "cx": state.cx,
+                    "cy": state.cy,
+                    "zoom": state.zoom,
+                    "crop_w": state.crop_w,
+                    "crop_h": state.crop_h,
+                    "used_label": state.used_label,
+                    "clamp_flags": state.clamp_flags,
+                }
+                telemetry_file.write(json.dumps(record) + "\n")
 
-        tmp_endcard = self.temp_root / "__endcard.mp4"
-        cmd_endcard = [
-            "ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
-            "-loop", "1", "-t", "1.0",
-            "-i", str(self.endcard_path),
-            "-f", "lavfi", "-t", "1.0", "-i",
-            "anullsrc=channel_layout=stereo:sample_rate=48000",
-            "-vf", f"scale={self.canvas_size[0]}:{self.canvas_size[1]}",
-            "-r", f"{fps:.6f}",
-            "-c:v", "libx264",
-            "-pix_fmt", "yuv420p",
-            "-profile:v", "high",
-            "-crf", "19",
-            "-c:a", "aac",
-            "-b:a", "192k",
-            "-shortest",
-            str(tmp_endcard),
-        ]
-        run_subprocess(cmd_endcard)
+        if telemetry_file:
+            telemetry_file.close()
 
-        concat_file = self.temp_root / "__concat.ffconcat"
-        concat_file.parent.mkdir(parents=True, exist_ok=True)
-        with concat_file.open("w", encoding="utf-8") as fh:
-            fh.write("ffconcat version 1.0\n")
-            fh.write(f"file '{tmp_main.as_posix()}'\n")
-            fh.write(f"file '{tmp_endcard.as_posix()}'\n")
+        endcard_frames = self._append_endcard(output_size)
+        if endcard_frames:
+            start_index = len(states)
+            for offset, endcard_frame in enumerate(endcard_frames):
+                out_path = self.temp_dir / f"f_{start_index + offset:06d}.jpg"
+                cv2.imwrite(str(out_path), endcard_frame, [int(cv2.IMWRITE_JPEG_QUALITY), 95])
 
-        cmd_concat = [
-            "ffmpeg", "-y", "-hide_banner", "-loglevel", "error",
-            "-f", "concat", "-safe", "0",
-            "-i", str(concat_file),
-            "-c", "copy",
+    def ffmpeg_stitch(
+        self,
+        crf: int,
+        keyint: int,
+        log_path: Optional[Path] = None,
+    ) -> None:
+        pattern = str(self.temp_dir / "f_%06d.jpg")
+        self.output_path.parent.mkdir(parents=True, exist_ok=True)
+
+        command = [
+            "ffmpeg",
+            "-y",
+            "-loglevel",
+            "error",
+            "-framerate",
+            str(self.fps_out),
+            "-i",
+            pattern,
+            "-i",
+            str(self.input_path),
+            "-map",
+            "0:v:0",
+            "-map",
+            "1:a:0?",
+            "-c:v",
+            "libx264",
+            "-preset",
+            "veryfast",
+            "-crf",
+            str(crf),
+            "-pix_fmt",
+            "yuv420p",
+            "-profile:v",
+            "high",
+            "-level",
+            "4.0",
+            "-x264-params",
+            f"keyint={keyint}:min-keyint={keyint}:scenecut=0",
+            "-movflags",
+            "+faststart",
+            "-c:a",
+            "aac",
+            "-b:a",
+            "128k",
             str(self.output_path),
         ]
-        run_subprocess(cmd_concat)
-        if not quiet:
-            print(f"Wrote {self.output_path}")
 
-    def render(self, fps: float, states: Sequence[CameraState], quiet: bool = False) -> int:
-        self.prepare_overlay()
-        frame_count = self.compose_frames(states, quiet=quiet)
-        self.ffmpeg_stitch(fps, quiet=quiet)
-        return frame_count
+        try:
+            subprocess.run(command, check=True)
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError("ffmpeg failed during stitching.") from exc
 
-
-# ---------------------------------------------------------------------------
-# Main workflow
-# ---------------------------------------------------------------------------
+        if log_path:
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            with log_path.open("a", encoding="utf-8") as handle:
+                handle.write(" ".join(command) + "\n")
 
 
-def main(argv: Optional[Sequence[str]] = None) -> int:
-    args = parse_args(argv)
-    input_path = Path(args.input).expanduser().resolve()
+def _prepare_temp_dir(temp_dir: Path, clean: bool) -> None:
+    if clean and temp_dir.exists():
+        shutil.rmtree(temp_dir)
+    if not temp_dir.exists():
+        temp_dir.mkdir(parents=True, exist_ok=True)
+        return
+    for file in temp_dir.glob("*.jpg"):
+        try:
+            file.unlink()
+        except OSError:
+            logging.warning("Failed to remove temp frame %s", file)
+
+
+def _default_output_path(input_path: Path, preset: str) -> Path:
+    suffix = f".__{preset.upper()}.mp4"
+    return input_path.with_name(input_path.stem + suffix)
+
+
+def run(args: argparse.Namespace) -> None:
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+
+    input_path = Path(args.in_path).expanduser().resolve()
     if not input_path.exists():
-        raise SystemExit(f"Input clip not found: {input_path}")
+        raise FileNotFoundError(f"Input file not found: {input_path}")
 
-    video_info = ffprobe_stream_info(input_path)
-    fps = float(args.fps or video_info.get("fps") or DEFAULT_FPS)
-    if fps <= 1e-3:
-        fps = DEFAULT_FPS
+    presets = load_presets()
+    preset_key = (args.preset or "cinematic").lower()
+    if preset_key not in presets:
+        raise ValueError(f"Preset '{preset_key}' not found in {PRESETS_PATH}")
 
-    renderer = Renderer(args, video_info)
-    renderer.extract_frames(fps=fps, quiet=args.quiet)
-    frame_files = sorted(renderer.frames_dir.glob("f_*.jpg"))
-    frame_count = len(frame_files)
-    if frame_count == 0:
-        raise RuntimeError("No frames extracted for processing")
+    preset_config = presets[preset_key]
 
-    label_store = LabelStore(Path(args.labels_root).expanduser().resolve())
-    try:
-        labels_sequence = label_store.build_sequence(renderer.input_path.stem, frame_count)
-    except Exception as exc:  # pragma: no cover - defensive
-        if not args.quiet:
-            print(f"Warning: failed to load labels ({exc})")
-        labels_sequence = [None] * frame_count
-    if not labels_sequence:
-        labels_sequence = [None] * frame_count
-    label_files_used = label_store.find_label_files(renderer.input_path.stem)
+    fps_in = ffprobe_fps(input_path)
+    fps_out = float(args.fps) if args.fps else float(preset_config.get("fps", fps_in))
+    if fps_out <= 0:
+        fps_out = fps_in if fps_in > 0 else 30.0
 
-    preset = PRESETS[args.preset]
-    lookahead = args.lookahead if args.lookahead is not None else preset["lookahead"]
-    smoothing = args.smoothing if args.smoothing is not None else preset["smoothing"]
-    pad = args.pad if args.pad is not None else preset["pad"]
+    portrait_str = args.portrait or preset_config.get("portrait")
+    portrait = parse_portrait(portrait_str) if portrait_str else None
 
-    focus_y = 0.4 if args.portrait else 0.5
+    lookahead = args.lookahead if args.lookahead is not None else preset_config.get("lookahead", 18)
+    smoothing = args.smoothing if args.smoothing is not None else preset_config.get("smoothing", 0.65)
+    pad = args.pad if args.pad is not None else preset_config.get("pad", 0.22)
+    speed_limit = args.speed_limit if args.speed_limit is not None else preset_config.get("speed_limit", 480)
+    zoom_min = args.zoom_min if args.zoom_min is not None else preset_config.get("zoom_min", 1.0)
+    zoom_max = args.zoom_max if args.zoom_max is not None else preset_config.get("zoom_max", 2.2)
+    crf = int(args.crf) if args.crf is not None else int(preset_config.get("crf", 19))
+    keyint_factor = int(args.keyint_factor) if args.keyint_factor is not None else int(preset_config.get("keyint_factor", 4))
+
+    output_path = Path(args.out) if args.out else _default_output_path(input_path, preset_key)
+    output_path = output_path.expanduser().resolve()
+
+    labels_root = Path(args.labels_root or "out/yolo").expanduser()
+    label_files = find_label_files(input_path.stem, labels_root)
+
+    capture = cv2.VideoCapture(str(input_path))
+    if not capture.isOpened():
+        raise RuntimeError("Unable to open input video for metadata extraction.")
+    width = int(capture.get(cv2.CAP_PROP_FRAME_WIDTH))
+    height = int(capture.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    frame_count = int(capture.get(cv2.CAP_PROP_FRAME_COUNT))
+    capture.release()
+
+    labels = load_labels(label_files, width, height)
+    positions, used_mask = interp_labels_to_fps(labels, frame_count, fps_in, fps_out)
+
     planner = CameraPlanner(
-        frame_size=(int(video_info.get("width") or 0), int(video_info.get("height") or 0)),
-        canvas_size=renderer.canvas_size,
-        fps=fps,
+        width=width,
+        height=height,
+        fps=fps_out,
         lookahead=lookahead,
         smoothing=smoothing,
         pad=pad,
-        speed_limit=preset["speed_limit"],
-        zoom_speed=preset["zoom_speed"],
-        focus_x=0.5,
-        focus_y=focus_y,
+        speed_limit=speed_limit,
+        zoom_min=zoom_min,
+        zoom_max=zoom_max,
+        portrait=portrait,
     )
-    states = planner.plan(labels_sequence if labels_sequence else [None] * frame_count)
+    states = planner.plan(positions, used_mask)
 
-    start_time = time.time()
-    rendered_frames = renderer.render(fps=fps, states=states, quiet=args.quiet)
-    elapsed = time.time() - start_time
+    temp_root = Path("out/autoframe_work")
+    temp_dir = temp_root / preset_key / input_path.stem
+    _prepare_temp_dir(temp_dir, args.clean_temp)
 
-    summary_line = (
-        f"preset={args.preset} frames={rendered_frames} fps={fps:.3f} "
-        f"labels={len(label_files_used)} output={renderer.output_path}"
+    brand_overlay_path = Path(args.brand_overlay).expanduser() if args.brand_overlay else None
+    endcard_path = Path(args.endcard).expanduser() if args.endcard else None
+    telemetry_path = Path(args.telemetry).expanduser() if args.telemetry else None
+
+    renderer = Renderer(
+        input_path=input_path,
+        output_path=output_path,
+        temp_dir=temp_dir,
+        fps_in=fps_in,
+        fps_out=fps_out,
+        flip180=args.flip180,
+        portrait=portrait,
+        brand_overlay=brand_overlay_path,
+        endcard=endcard_path,
+        telemetry_path=telemetry_path,
     )
-    if not args.quiet:
-        print(summary_line)
 
-    log_json = {
-        "input": str(renderer.input_path),
-        "output": str(renderer.output_path),
-        "preset": args.preset,
-        "fps": fps,
-        "frames": rendered_frames,
-        "labels_present": bool(any(labels_sequence)),
-        "label_files": [str(p) for p in label_files_used],
-        "pad": pad,
-        "lookahead": lookahead,
-        "smoothing": smoothing,
-        "flip180": bool(args.flip180),
-        "portrait": renderer.canvas_size,
-        "brand_overlay": str(renderer.overlay_path) if renderer.overlay_path else None,
-        "endcard": str(renderer.endcard_path) if renderer.endcard_path else None,
-        "temp_root": str(renderer.temp_root),
-        "time_sec": elapsed,
-    }
-    renderer.log_path.write_text(summary_line + "\n", encoding="utf-8")
-    renderer.log_path.with_suffix(renderer.log_path.suffix + ".json").write_text(
-        json.dumps(log_json, indent=2), encoding="utf-8"
-    )
-    return 0
+    renderer.write_frames(states)
+
+    keyint = max(1, int(round(keyint_factor * fps_out)))
+    log_path = Path(args.log).expanduser() if args.log else None
+    renderer.ffmpeg_stitch(crf=crf, keyint=keyint, log_path=log_path)
+
+    if log_path:
+        with log_path.open("a", encoding="utf-8") as handle:
+            handle.write(
+                json.dumps(
+                    {
+                        "input": str(input_path),
+                        "output": str(output_path),
+                        "fps_in": fps_in,
+                        "fps_out": fps_out,
+                        "labels_found": len(labels),
+                        "preset": preset_key,
+                    }
+                )
+                + "\n"
+            )
 
 
-if __name__ == "__main__":
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Unified cinematic ball-follow renderer")
+    parser.add_argument("--in", dest="in_path", required=True, help="Input MP4 path")
+    parser.add_argument("--src", dest="src", help="Legacy compatibility input path (ignored)")
+    parser.add_argument("--out", dest="out", help="Output MP4 path")
+    parser.add_argument("--preset", dest="preset", choices=["cinematic", "gentle", "realzoom"], default="cinematic")
+    parser.add_argument("--portrait", dest="portrait", help="Portrait canvas WxH")
+    parser.add_argument("--fps", dest="fps", type=float, help="Output FPS")
+    parser.add_argument("--flip180", dest="flip180", action="store_true", help="Rotate frames by 180 degrees before processing")
+    parser.add_argument("--labels-root", dest="labels_root", help="Root directory containing YOLO label shards")
+    parser.add_argument("--clean-temp", dest="clean_temp", action="store_true", help="Remove temporary frame folder before rendering")
+    parser.add_argument("--lookahead", dest="lookahead", type=int, help="Frames of lookahead for planning")
+    parser.add_argument("--smoothing", dest="smoothing", type=float, help="EMA smoothing factor")
+    parser.add_argument("--pad", dest="pad", type=float, help="Edge padding ratio used to derive zoom")
+    parser.add_argument("--speed-limit", dest="speed_limit", type=float, help="Maximum pan speed in px/sec")
+    parser.add_argument("--zoom-min", dest="zoom_min", type=float, help="Minimum zoom multiplier")
+    parser.add_argument("--zoom-max", dest="zoom_max", type=float, help="Maximum zoom multiplier")
+    parser.add_argument("--telemetry", dest="telemetry", help="Output JSONL telemetry file")
+    parser.add_argument("--brand-overlay", dest="brand_overlay", help="PNG overlay composited on every frame")
+    parser.add_argument("--endcard", dest="endcard", help="Optional endcard image displayed for ~2 seconds")
+    parser.add_argument("--log", dest="log", help="Optional render log path")
+    parser.add_argument("--crf", dest="crf", type=int, help="Override CRF value")
+    parser.add_argument("--keyint-factor", dest="keyint_factor", type=int, help="Override keyint factor")
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    run(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
     try:
-        raise SystemExit(main())
-    except subprocess.CalledProcessError as exc:  # pragma: no cover - CLI
-        if exc.stderr:
-            print(exc.stderr, file=sys.stderr)
-        raise SystemExit(exc.returncode)
+        main()
+    except Exception as exc:  # pylint: disable=broad-except
+        logging.error(str(exc))
+        sys.exit(1)

--- a/tools/render_presets.yaml
+++ b/tools/render_presets.yaml
@@ -1,0 +1,33 @@
+cinematic:
+  fps: 30
+  portrait: "1080x1920"
+  lookahead: 18
+  smoothing: 0.65
+  pad: 0.22
+  speed_limit: 480
+  zoom_min: 1.0
+  zoom_max: 2.2
+  crf: 19
+  keyint_factor: 4
+gentle:
+  fps: 30
+  portrait: "1080x1920"
+  lookahead: 12
+  smoothing: 0.55
+  pad: 0.20
+  speed_limit: 360
+  zoom_min: 1.0
+  zoom_max: 1.8
+  crf: 20
+  keyint_factor: 4
+realzoom:
+  fps: 30
+  portrait: "1080x1920"
+  lookahead: 10
+  smoothing: 0.50
+  pad: 0.18
+  speed_limit: 520
+  zoom_min: 1.0
+  zoom_max: 2.4
+  crf: 19
+  keyint_factor: 4


### PR DESCRIPTION
## Summary
- replace the legacy follow scripts with a single `tools/render_follow_unified.py` renderer that implements label-driven ball lock, smoothing, portrait framing, logging, and ffmpeg stitching
- ship preset management plus helper utilities (`tools/render_presets.yaml`, `tools/calibrate_from_clip.py`, `tools/overlay_debug.py`) and document the workflow in `tools/README_render.md`
- refresh `tools/render_follow.ps1` so the PowerShell wrapper drives the unified renderer with preset-aware defaults

## Testing
- python tools/render_follow_unified.py --help
- python tools/calibrate_from_clip.py --help
- python tools/overlay_debug.py --help
- python -m compileall tools/render_follow_unified.py tools/calibrate_from_clip.py tools/overlay_debug.py


------
https://chatgpt.com/codex/tasks/task_e_68e56ab03a38832d9a91de9468fde460