### PR TITLE
Add crop box telemetry and update overlay debug rendering

### DIFF
--- a/tools/overlay_debug.py
+++ b/tools/overlay_debug.py
@@ -58,18 +58,31 @@ def _sample_frame(frames: List[np.ndarray], fps_in: float, fps_out: float, index
 
 def _draw(frame: np.ndarray, telemetry: dict, label_point: Optional[np.ndarray]) -> np.ndarray:
     output = frame.copy()
-    cx = telemetry.get("cx", 0.0)
-    cy = telemetry.get("cy", 0.0)
-    crop_w = telemetry.get("crop_w", 0.0)
-    crop_h = telemetry.get("crop_h", 0.0)
 
-    x1 = int(round(cx - crop_w / 2.0))
-    y1 = int(round(cy - crop_h / 2.0))
-    x2 = int(round(cx + crop_w / 2.0))
-    y2 = int(round(cy + crop_h / 2.0))
-    cv2.rectangle(output, (x1, y1), (x2, y2), (0, 255, 0), 2)
+    crop = telemetry.get("crop")
+    if crop and len(crop) >= 4:
+        x0, y0, crop_w, crop_h = crop[:4]
+    else:
+        cx = telemetry.get("cx", 0.0)
+        cy = telemetry.get("cy", 0.0)
+        crop_w = telemetry.get("crop_w", 0.0)
+        crop_h = telemetry.get("crop_h", 0.0)
+        x0 = cx - crop_w / 2.0
+        y0 = cy - crop_h / 2.0
 
-    if label_point is not None and not np.isnan(label_point).any():
+    cv2.rectangle(
+        output,
+        (int(x0), int(y0)),
+        (int(x0 + crop_w), int(y0 + crop_h)),
+        (0, 255, 0),
+        2,
+    )
+
+    ball = telemetry.get("ball")
+    if ball and len(ball) >= 2:
+        bx, by = ball[:2]
+        cv2.circle(output, (int(bx), int(by)), 6, (0, 0, 255), -1)
+    elif label_point is not None and not np.isnan(label_point).any():
         cv2.circle(output, (int(label_point[0]), int(label_point[1])), 8, (0, 0, 255), -1)
 
     used = telemetry.get("used_label", False)

--- a/tools/render_follow_unified.py
+++ b/tools/render_follow_unified.py
@@ -385,6 +385,7 @@ class CamState:
     y0: float
     used_label: bool
     clamp_flags: List[str]
+    ball: Optional[Tuple[float, float]] = None
 
 
 class CameraPlanner:
@@ -537,6 +538,7 @@ class CameraPlanner:
                     y0=y0,
                     used_label=bool(has_position),
                     clamp_flags=clamp_flags,
+                    ball=(float(pos[0]), float(pos[1])) if has_position else None,
                 )
             )
 
@@ -691,6 +693,13 @@ class Renderer:
                     "crop_h": float(state.crop_h),
                     "x0": float(state.x0),
                     "y0": float(state.y0),
+                    "crop": [
+                        float(state.x0),
+                        float(state.y0),
+                        float(state.crop_w),
+                        float(state.crop_h),
+                    ],
+                    "ball": [float(state.ball[0]), float(state.ball[1])] if state.ball else None,
                     "used_label": bool(state.used_label),
                     "clamp_flags": list(state.clamp_flags)
                     if isinstance(state.clamp_flags, (set, tuple))


### PR DESCRIPTION
## Summary
- include the crop rectangle and ball position in telemetry records produced by the renderer
- update the overlay debug tool to draw the recorded crop and ball in source coordinates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e586695404832d9944da257b9e2b34