### PR TITLE
Add typing and numpy imports to overlay_debug

### DIFF
--- a/tools/overlay_debug.py
+++ b/tools/overlay_debug.py
@@ -2,7 +2,9 @@
 # tools/overlay_debug.py — self-contained overlay from JSONL telemetry
 import argparse, json, os
 from pathlib import Path
+from typing import List
 import cv2
+import numpy as np
 
 def read_jsonl(p):
     recs = []


### PR DESCRIPTION
## Summary
- import typing.List and numpy in overlay_debug script to support future usage

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e58fd22cb8832da7ce97435482c76f