### PR TITLE
Add offline ball path planner and renderer support

### DIFF
--- a/tools/ball_path_offline.py
+++ b/tools/ball_path_offline.py
@@ -1,0 +1,306 @@
+import argparse
+import json
+import math
+from collections import namedtuple
+
+import cv2
+import numpy as np
+
+
+# ---- basic helpers ----
+def build_ball_mask(bgr, grass_h=(35, 95), min_v=170, max_s=120):
+    hsv = cv2.cvtColor(bgr, cv2.COLOR_BGR2HSV)
+    H, S, V = cv2.split(hsv)
+    non_grass = (H < grass_h[0]) | (H > grass_h[1])
+    bright = V >= min_v
+    low_sat = S <= max_s
+    mask = ((non_grass & bright) | (bright & low_sat)).astype(np.uint8) * 255
+    mask = cv2.medianBlur(mask, 5)
+    mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, np.ones((3, 3), np.uint8))
+    return mask
+
+
+def circularity(cnt):
+    a = cv2.contourArea(cnt)
+    p = cv2.arcLength(cnt, True)
+    if p <= 0 or a <= 0:
+        return 0.0
+    return float(4 * math.pi * a / (p * p))
+
+
+def ncc_score(gray_win, tpl_gray):
+    if gray_win.size == 0 or tpl_gray.size == 0:
+        return -1.0
+    if (
+        gray_win.shape[0] < tpl_gray.shape[0]
+        or gray_win.shape[1] < tpl_gray.shape[1]
+    ):
+        return -1.0
+    g = cv2.equalizeHist(gray_win)
+    t = cv2.equalizeHist(tpl_gray)
+    r1 = cv2.matchTemplate(g, t, cv2.TM_CCOEFF_NORMED).max()
+    h, w = t.shape[:2]
+    tw, th = max(3, int(w * 0.75)), max(3, int(h * 0.75))
+    t2 = cv2.resize(t, (tw, th), interpolation=cv2.INTER_AREA)
+    r2 = cv2.matchTemplate(g, t2, cv2.TM_CCOEFF_NORMED).max()
+    return float(max(r1, r2))
+
+
+def extract_tpl(gray, x, y, side, W, H):
+    x0 = int(max(0, x - side // 2))
+    y0 = int(max(0, y - side // 2))
+    x1 = int(min(W, x0 + side))
+    y1 = int(min(H, y0 + side))
+    return gray[y0:y1, x0:x1].copy()
+
+
+# ---- candidate generator ----
+Cand = namedtuple("Cand", "x y score ncc circ dist")
+
+
+def gen_candidates(
+    frame_bgr,
+    pred_xy,
+    tpl=None,
+    search_r=280,
+    min_r=6,
+    max_r=22,
+    min_circ=0.58,
+    max_cands=12,
+):
+    H, W = frame_bgr.shape[:2]
+    px, py = pred_xy
+    x0 = int(max(0, px - search_r))
+    y0 = int(max(0, py - search_r))
+    x1 = int(min(W, px + search_r))
+    y1 = int(min(H, py + search_r))
+    roi = frame_bgr[y0:y1, x0:x1]
+    if roi.size == 0:
+        return []
+
+    mask = build_ball_mask(roi)
+    cnts, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    if not cnts:
+        return []
+
+    gray_roi = cv2.cvtColor(roi, cv2.COLOR_BGR2GRAY)
+    out = []
+    for c in cnts:
+        a = cv2.contourArea(c)
+        if a < (min_r * min_r * 0.6) or a > (max_r * max_r * 3.5):
+            continue
+        circ = circularity(c)
+        if circ < min_circ:
+            continue
+        (cx, cy), rad = cv2.minEnclosingCircle(c)
+        bx = x0 + cx
+        by = y0 + cy
+        ncc = 0.0
+        if tpl is not None:
+            side = int(max(16, min(96, rad * 6)))
+            sx0 = int(max(0, bx - side // 2))
+            sy0 = int(max(0, by - side // 2))
+            sx1 = int(min(W, sx0 + side))
+            sy1 = int(min(H, sy0 + side))
+            win = gray_roi[(sy0 - y0) : (sy1 - y0), (sx0 - x0) : (sx1 - x0)]
+            ncc = ncc_score(win, tpl)
+        dist = math.hypot(bx - px, by - py)
+        score = (-0.02 * dist) + (3.0 * circ) + (1.8 * ncc)
+        out.append(
+            Cand(float(bx), float(by), float(score), float(ncc), float(circ), float(dist))
+        )
+    out.sort(key=lambda c: c.score, reverse=True)
+    return out[:max_cands]
+
+
+# ---- dynamic programming over time ----
+def solve_path(
+    cand_lists,
+    start_xy,
+    lam_vel=0.06,
+    lam_acc=0.02,
+    miss_penalty=1.5,
+    max_jump=220.0,
+):
+    """Solve best ball path over candidate lists via dynamic programming."""
+
+    N = len(cand_lists)
+    MISS = Cand(np.nan, np.nan, -999.0, 0.0, 0.0, 0.0)
+    C = [c + [MISS] for c in cand_lists]
+    K = [len(c) for c in C]
+
+    INF = 1e15
+    dp = [np.full(k, INF, dtype=np.float64) for k in K]
+    prv = [np.full(k, -1, dtype=np.int32) for k in K]
+
+    sx, sy = start_xy
+    for j, c in enumerate(C[0]):
+        if np.isnan(c.x):
+            dp[0][j] = miss_penalty
+        else:
+            jump = math.hypot(c.x - sx, c.y - sy)
+            dp[0][j] = -c.score + lam_vel * jump
+
+    for t in range(1, N):
+        cand_t = C[t]
+        cand_p = C[t - 1]
+        for j, cj in enumerate(cand_t):
+            for i, ci in enumerate(cand_p):
+                if np.isnan(cj.x) and np.isnan(ci.x):
+                    cost = dp[t - 1][i] + miss_penalty
+                else:
+                    xj, yj = (cj.x, cj.y) if not np.isnan(cj.x) else (ci.x, ci.y)
+                    xi, yi = (ci.x, ci.y) if not np.isnan(ci.x) else (xj, yj)
+                    if not np.isnan(xi) and not np.isnan(xj):
+                        jump = math.hypot(xj - xi, yj - yi)
+                        if jump > max_jump:
+                            continue
+                    unary = miss_penalty if np.isnan(cj.x) else (-cj.score)
+                    pair = (
+                        0
+                        if np.isnan(xi) or np.isnan(xj)
+                        else lam_vel * math.hypot(xj - xi, yj - yi)
+                    )
+                    cost = dp[t - 1][i] + unary + pair
+                if cost < dp[t][j]:
+                    dp[t][j] = cost
+                    prv[t][j] = i
+
+    j = int(np.argmin(dp[-1]))
+    path = [None] * N
+    for t in range(N - 1, -1, -1):
+        c = C[t][j]
+        path[t] = (c.x, c.y, ("miss" if np.isnan(c.x) else "cand"))
+        j = int(prv[t][j]) if t > 0 and prv[t][j] >= 0 else j
+
+    last = None
+    for t in range(N):
+        x, y, src = path[t]
+        if np.isnan(x) or np.isnan(y):
+            if last is None:
+                last = (sx, sy)
+            path[t] = (last[0], last[1], "pred")
+        else:
+            last = (x, y)
+    return path
+
+
+def rts_smooth(path, k_alpha_pos=0.35, k_alpha_vel=0.25, iters=1):
+    """Simple forward-backward EMA to reduce jitter."""
+
+    xs = [p[0] for p in path]
+    ys = [p[1] for p in path]
+    vx = [0.0] * len(xs)
+    vy = [0.0] * len(xs)
+
+    for t in range(1, len(xs)):
+        px, py = xs[t - 1] + vx[t - 1], ys[t - 1] + vy[t - 1]
+        rx, ry = xs[t] - px, ys[t] - py
+        vx[t] = vx[t - 1] + k_alpha_vel * rx
+        vy[t] = vy[t - 1] + k_alpha_vel * ry
+        xs[t] = (1 - k_alpha_pos) * px + k_alpha_pos * xs[t]
+        ys[t] = (1 - k_alpha_pos) * py + k_alpha_pos * ys[t]
+
+    for t in range(len(xs) - 2, -1, -1):
+        px, py = xs[t + 1] - vx[t + 1], ys[t + 1] - vy[t + 1]
+        rx, ry = xs[t] - px, ys[t] - py
+        vx[t] = vx[t + 1] - k_alpha_vel * rx
+        vy[t] = vy[t + 1] - k_alpha_vel * ry
+        xs[t] = (1 - k_alpha_pos) * px + k_alpha_pos * xs[t]
+        ys[t] = (1 - k_alpha_pos) * py + k_alpha_pos * ys[t]
+
+    return list(zip(xs, ys))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="inp", required=True)
+    ap.add_argument("--init-t", type=float, default=0.8)
+    ap.add_argument("--init-manual", action="store_true")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--max-cands", type=int, default=12)
+    ap.add_argument("--search-r", type=int, default=280)
+    args = ap.parse_args()
+
+    cap = cv2.VideoCapture(args.inp)
+    if not cap.isOpened():
+        raise SystemExit("Cannot open input")
+    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    W = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    H = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+
+    idx0 = max(0, int(round(args.init_t * fps)))
+    cap.set(cv2.CAP_PROP_POS_FRAMES, idx0)
+    ok, frame0 = cap.read()
+    if not ok:
+        raise SystemExit("Cannot read init frame")
+
+    if args.init_manual and hasattr(cv2, "selectROI"):
+        cv2.namedWindow("Select ball", cv2.WINDOW_NORMAL)
+        r = cv2.selectROI(
+            "Select ball", frame0, showCrosshair=True, fromCenter=False
+        )
+        cv2.destroyWindow("Select ball")
+        if r is None or r[2] <= 0 or r[3] <= 0:
+            raise SystemExit("No ROI selected")
+        bx0 = r[0] + r[2] / 2.0
+        by0 = r[1] + r[3] / 2.0
+    else:
+        raise SystemExit("Use --init-manual on this first run")
+
+    tpl = extract_tpl(
+        cv2.cvtColor(frame0, cv2.COLOR_BGR2GRAY), int(bx0), int(by0), 64, W, H
+    )
+
+    cand_lists = []
+    positions = []
+    cap.set(cv2.CAP_PROP_POS_FRAMES, 0)
+    n = 0
+    while True:
+        ok, frame = cap.read()
+        if not ok:
+            break
+        if n == 0:
+            pred = (bx0, by0)
+        else:
+            pred = positions[-1] if positions else (bx0, by0)
+        cands = gen_candidates(
+            frame,
+            pred,
+            tpl,
+            search_r=args.search_r,
+            max_cands=args.max_cands,
+        )
+        cand_lists.append(cands)
+        if cands:
+            positions.append((cands[0].x, cands[0].y))
+            g = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+            cur = extract_tpl(g, int(cands[0].x), int(cands[0].y), 64, W, H)
+            if cur.size and tpl.size and cur.shape == tpl.shape:
+                tpl = cv2.addWeighted(tpl, 0.9, cur, 0.1, 0)
+        else:
+            positions.append(positions[-1] if positions else (bx0, by0))
+        n += 1
+    cap.release()
+
+    path = solve_path(
+        cand_lists,
+        (bx0, by0),
+        lam_vel=0.08,
+        lam_acc=0.02,
+        miss_penalty=1.1,
+        max_jump=240.0,
+    )
+    smoothed = rts_smooth(path, k_alpha_pos=0.42, k_alpha_vel=0.30, iters=1)
+
+    with open(args.out, "w", encoding="utf-8") as f:
+        for i, ((x, y, src), (sx, sy)) in enumerate(zip(path, smoothed)):
+            t = i / float(fps)
+            f.write(
+                json.dumps({"t": t, "bx": float(sx), "by": float(sy), "src": src})
+                + "\n"
+            )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a two-pass offline ball tracker that builds and smooths a full-path JSONL
- allow render_follow_unified.py to consume precomputed ball paths via a new CLI flag
- fall back to existing tracking logic when no offline path is provided

## Testing
- `python -m compileall tools/ball_path_offline.py tools/render_follow_unified.py`


------
https://chatgpt.com/codex/tasks/task_e_68e65a74e4f8832d8a9abd73e4b5d24d