### PR TITLE
Add roster opener builder script with improved file discovery

### DIFF
--- a/Build-TSCOpenersFromFolder.ps1
+++ b/Build-TSCOpenersFromFolder.ps1
@@ -1,0 +1,60 @@
+<# Build-TSCOpenersFromFolder.ps1 (patched)
+   - Fixes Get-ChildItem filter so files are actually found
+   - Accepts any dash character between Name and Number
+   - Adds simple discovery stats + per-file echo
+#>
+
+# --- Your paths ---
+$RosterDir    = "C:\Users\scott\OneDrive\Desktop\Personal\Photos\Kids Games\Claire\Photo Circle\Roster"
+$OpenerScript = "C:\Users\scott\soccer-video\New-TSCOpeningTitle.ps1"
+$OutRoot      = "C:\Users\scott\soccer-video\out\opener"
+
+# --- Prep ---
+if (!(Test-Path $RosterDir))    { throw "Roster folder not found: $RosterDir" }
+if (!(Test-Path $OpenerScript)) { throw "Opener script not found: $OpenerScript" }
+$null = New-Item -ItemType Directory -Force -Path $OutRoot
+
+# Accept hyphen, en dash, em dash, minus, etc.
+# Example matches: "Claire Briggs - 14.jpg" / "Claire Briggs – 14.JPG"
+$regex = '^(?<name>.+?)\s*[\p{Pd}]\s*(?<num>\d+)\.(jpg|jpeg|png)$'
+$manifest = @()
+
+# IMPORTANT: use wildcard with -Include so it returns files
+$files = Get-ChildItem -Path (Join-Path $RosterDir '*') -File -Include *.jpg,*.jpeg,*.png
+Write-Host ("Found {0} image(s) in roster folder" -f $files.Count)
+
+foreach ($f in $files) {
+  $m = [regex]::Match($f.Name, $regex, [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+  if (-not $m.Success) {
+    Write-Warning "Skipping (name pattern not matched): $($f.Name)"
+    continue
+  }
+
+  $name = $m.Groups['name'].Value.Trim()
+  $num  = $m.Groups['num'].Value.Trim()
+
+  # Sanitize for file names
+  $safeName = ($name -replace '[^\w\s\-]', '_').Trim()
+  $outOpener = Join-Path $OutRoot ("TSC_Opener__{0}_{1}.mp4" -f $num, $safeName)
+
+  Write-Host "==> Building opener for $name  #$num"
+  & $OpenerScript `
+      -PlayerImg  $f.FullName `
+      -PlayerName $name `
+      -PlayerNo   $num `
+      -OutOpener  $outOpener
+
+  $manifest += [pscustomobject]@{
+    PlayerName = $name
+    PlayerNo   = $num
+    ImagePath  = $f.FullName
+    OpenerPath = $outOpener
+    BuiltAt    = (Get-Date)
+  }
+}
+
+# Write a quick manifest for reference
+$csv = Join-Path $OutRoot "openers_manifest.csv"
+$manifest | Export-Csv -NoTypeInformation -Encoding UTF8 $csv
+Write-Host "`nAll done. Opener files in: $OutRoot"
+Write-Host "Manifest: $csv"


### PR DESCRIPTION
## Summary
- add a Build-TSCOpenersFromFolder.ps1 helper to generate opener videos from roster photos
- ensure roster images are discovered reliably and support multiple dash characters in filenames
- log per-file processing and export a manifest of generated openers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e67a5712c8832d90f002f03e566939